### PR TITLE
make node-sass be npm-requirable

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "wrapper around libsass",
   "version": "0.0.0",
   "homepage": "http://github.com/andrew/node-sass",
+  "main": "./sass.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/andrew/node-sass.git"


### PR DESCRIPTION
When node-sass is installed as a dependency of another node-js module or application, the sass module is not require-able using "require('sass')" because there is no "main" property defined in the package.json.
This commit adds this "main" property.
