### PR TITLE
Add support for node 0.6, 0.8

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,28 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'type': '<(library)',
+      'sources': [
+        'binding.cpp',
+        'libsass/context.cpp',
+        'libsass/document.cpp',
+        'libsass/document_parser.cpp',
+        'libsass/eval_apply.cpp',
+        'libsass/functions.cpp',
+        'libsass/node.cpp',
+        'libsass/node_emitters.cpp',
+        'libsass/node_factory.cpp',
+        'libsass/prelexer.cpp',
+        'libsass/sass_interface.cpp'
+      ],
+      'conditions': [
+        ['OS=="mac"', {
+          'xcode_settings': {
+            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+          }
+         }]
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
     "type": "git",
     "url": "git://github.com/andrew/node-sass.git"
   },
+  "scripts": {
+    "install": "node-gyp rebuild"
+  },
+  "engines": {
+    "node": ">=0.6.4"
+  },
   "dependencies": {
     "mkdirp": "0.3.x"
   },


### PR DESCRIPTION
I saw you post a message to the node mailing list and am making a very minor contribution here.

I added a gyp file so that it will work for node 0.6 - 0.8 since node-waf is being discontinued.  All you have to do is type "npm install" to have it work under node 0.6 (gyp is lots easier than waf)
