### PR TITLE
Pass options to render from middleware

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -74,7 +74,8 @@ module.exports = function(options){
     var path = url.parse(req.url).pathname;
     if (/\.css$/.test(path)) {
       var cssPath = join(dest, path)
-        , sassPath = join(src, path.replace('.css', '.scss'));
+        , sassPath = join(src, path.replace('.css', '.scss'))
+        , sassDir = dirname(sassPath)
 
       if (debug) {
         log('source', sassPath);
@@ -107,6 +108,9 @@ module.exports = function(options){
               if (err) return error(err);
               fs.writeFile(cssPath, css, 'utf8', next);
             });
+          }, {
+            include_paths: [ sassDir ].concat(options.include_paths || []),
+            output_style: options.output_style
           });
         });
       }


### PR DESCRIPTION
Always include the directory of the scss file as the first path in include_paths
