### PR TITLE
Variables in mixin not rendering properly

### DIFF
--- a/test/assets/mixins.scss
+++ b/test/assets/mixins.scss
@@ -1,0 +1,13 @@
+@mixin bgColor($color){
+  background: $color;
+}
+
+@mixin bgUrl($path){
+  background: url($path);
+}
+
+body {
+  @include bgColor(#f9cf3e);
+  @include bgUrl("/path/to/some/image.png");
+}
+

--- a/test/assets/mixins_expected_output.css
+++ b/test/assets/mixins_expected_output.css
@@ -1,0 +1,3 @@
+body {
+  background: #f9cf3e;
+  background: url("/path/to/some/image.png"); }

--- a/test/mixins_test.js
+++ b/test/mixins_test.js
@@ -1,0 +1,16 @@
+var fs = require('fs');
+var sass = require('../sass');
+var assert = require('assert');
+
+describe("compiling input with mixins", function() {
+  var input = fs.readFileSync('test/assets/mixins.scss', 'utf8');
+  var expectedRender = fs.readFileSync('test/assets/mixins_expected_output.css', 'utf8');
+
+  it("should compile", function(done) {
+    sass.render(input, function(err, css) {
+      if (err) { done(err) }
+      assert.equal(css, expectedRender);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
There's a discrepancy between the way the normal sass cli renders mixin variables and the way that node-sass. Came across this while testing a pull request for [https://github.com/imulus/retinajs](https://github.com/imulus/retinajs)

It appears to be isolated to outputting a variable inside a background url like this:

``` scss
backgrounds: url($someVariable);
```

Instead of rendering the variable as an interpolated expression, it seems to render the variable itself as a string literal.

I've included a test to demonstrate the bug, just run `npm test`.

Repro steps:
1. Compile test/assets/mixins.scss to test/assets/mixins_expected_output.css using SASS cli
2. Test output of `sass.render` with the contents of test/assets/mixins.scss as the input source against expected output compiled from SASS cli

The `bgColor()` mixin compiles as expected, but the `bgUrl()` mixin does not compile the variable properly, instead it outputs the variable as a literal.

``` bash
node-sass [bug/mixins !] $ which sass
/usr/local/Cellar/ruby/1.9.2-p290/bin/sass

node-sass [bug/mixins !] $ sass -v
Sass 3.2.3 (Media Mark)

node-sass [bug/mixins !] $ sass test/assets/mixins.scss > test/assets/mixins_expected_output.css 

node-sass [bug/mixins !] $ cat test/assets/mixins_expected_output.css 
body {
  background: #f9cf3e;
  background: url("/path/to/some/image.png"); }

node-sass [bug/mixins !] $ npm test

> node-sass@0.2.5 test /Users/caseyohara/Desktop/node-sass
> mocha test


  ․․․

  ✖ 1 of 3 tests failed:

  1) compiling input with mixins should compile:

      actual expected

      body {<LF>
        background: #f9cf3e;<LF>
        background: url("/("$path/to/some/image.png"); }<LF>


  AssertionError: "body {\n  background: #f9cf3e;\n  background: url(\"$path\"); }\n" == "body {\n  background: #f9cf3e;\n  background: url(\"/path/to/some/image.png\"); }\n"
      at /Users/caseyohara/Desktop/node-sass/test/mixins_test.js:12:14



npm ERR! node-sass@0.2.5 test: `mocha test`
npm ERR! `sh "-c" "mocha test"` failed with 1
npm ERR! 
npm ERR! Failed at the node-sass@0.2.5 test script.
npm ERR! This is most likely a problem with the node-sass package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     mocha test
npm ERR! You can get their info via:
npm ERR!     npm owner ls node-sass
npm ERR! There is likely additional logging output above.
npm ERR! 
npm ERR! System Darwin 11.4.2
npm ERR! command "node" "/usr/local/bin/npm" "test"
npm ERR! cwd /Users/caseyohara/Desktop/node-sass
npm ERR! node -v v0.8.0
npm ERR! npm -v 1.1.16
npm ERR! code ELIFECYCLE
npm ERR! message node-sass@0.2.5 test: `mocha test`
npm ERR! message `sh "-c" "mocha test"` failed with 1
npm ERR! errno {}
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/caseyohara/Desktop/node-sass/npm-debug.log
npm not ok
```
