### PR TITLE
Response to Issue 65

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -2,6 +2,7 @@
 var colors    = require('colors');
 var fs        = require('fs');
 var sass      = require('../sass');
+var path      = require('path');
 var fileName  = process.argv[2];
 var cssFileName = process.argv[3];
 
@@ -28,6 +29,14 @@ function renderSASS(data) {
       console.log(JSON.stringify(err, null, 4).yellow);
     } else {
       console.log('Rendering Complete, saving .css file...'.green);
+
+      var outFile
+      if (cssFileName) {
+        outFile = cssFileName;
+      } else {
+        outFile = fileName.slice(fileName.lastIndexOf('/') + 1,
+                  fileName.lastIndexOf('.')) + '.css';
+      }
 
       var outFile = (cssFileName) ? cssFileName : 'nodesass.css';
       writeCssFile(outFile, compiled);


### PR DESCRIPTION
Changed the default file name for generated CSS files from nodesass.css
to <originalfilename-without-scss>.css.

Now it should be possible to use globbing and get all generated files in
ones current working directory:

./path/to/node-sass path/to/styles/*.scss

generates all CSS files named like their SCSS counterparts.
