### PR TITLE
The includePaths option is missing from middleware.js

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -110,7 +110,7 @@ module.exports = function(options){
               fs.writeFile(cssPath, css, 'utf8', next);
             });
           }, {
-            include_paths: [ sassDir ].concat(options.include_paths || []),
+            include_paths: [ sassDir ].concat(options.include_paths || options.includePaths || []),
             output_style: options.output_style || options.outputStyle
           });
         });


### PR DESCRIPTION
Currently it is possible to define a render option with the key include_paths OR includePaths. This is true if you are using the sass modules render method. This is also true for output_style and outputStyle.

However if using the middleware implementation the includePaths key is not supported. I've updated middleware.js to add support. Note that both output_style and outputStyle are already supported by middleware.
