### PR TITLE
Cleaner, non-breaking, path handling for source and destination with a shared root

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -64,6 +64,8 @@ module.exports = function(options){
     ? options.dest
     : src;
 
+  var root = options.root || null;
+
   // Default compile callback
   options.compile = options.compile || function(){
     return sass
@@ -76,7 +78,15 @@ module.exports = function(options){
     if (/\.css$/.test(path)) {
       var cssPath = join(dest, path)
         , sassPath = join(src, path.replace('.css', '.scss'))
-        , sassDir = dirname(sassPath)
+        , sassDir = dirname(sassPath);
+
+      if (root) {
+        cssPath = join(root, dest, path.replace(dest, ''));
+        sassPath = join(root, src, path
+            .replace(dest, '')
+            .replace('.css', '.scss'));
+        sassDir = dirname(sassPath);
+      }
 
       if (debug) {
         log('source', sassPath);


### PR DESCRIPTION
If a root value is supplied in the options for this middleware, then the dest and src values are relative this this location. They should also use the standard URI path separators.

When this is done, the setup looks something like this (for express):

``` javascript
  app.use(sass.middleware({
    src: '/sass',
    dest: '/css',
    root: path.join(__dirname, 'public')
  }));
```

A call to /css/some/path/file.css will build the paths such as

```
dest: /css/some/path/file.css
src:  /sass/some/path/file.scss
```

The old version of the code, given a setup of the following:

``` javascript
  app.use(sass.middleware({
    src: path.join(__dirname, 'public', 'sass'),
    dest: path.join(__dirname, 'public', 'css')
  }));
```

would have generated paths such as:

```
dest: '/css/css/some/path.css'
src: '/sass/css/some/path.scss'
```

You should be able to see the unnecessary '/css/' path structures within. This just makes things messy and for no real good reason.
