### PR TITLE
installation failes on windows : --msvs_version npm flag ignored during binding build

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "url": "git://github.com/andrew/node-sass.git"
   },
   "scripts": {
-    "install": "node rebuild.js",
     "test": "mocha test"
   },
   "bin": {

--- a/rebuild.js
+++ b/rebuild.js
@@ -1,3 +1,0 @@
-var spawn = require('child_process').spawn;
-
-spawn('node-gyp', ['rebuild']);


### PR DESCRIPTION
When installing via npm with the "--msvs_version" option, it is ignored.

This is due to custom install script in package.json, which should be replaced with the automatic node-gyp call performed by npm which passes the option automatically.

npm searches for binding.gyp and automatically calls node-gyp with the appropriate options.
(https://npmjs.org/doc/json.html)
