### PR TITLE
Fixed #167 where multiple instances of Optimist would conflict.

### DIFF
--- a/sass.js
+++ b/sass.js
@@ -89,4 +89,3 @@ exports.renderSync = function(options) {
 };
 
 exports.middleware = require('./lib/middleware');
-exports.cli = require('./lib/cli');


### PR DESCRIPTION
I removed the export of the cli interface since there is no documentation of it, nor is it being used anywhere within the library. I think this is the best solution.
