### PR TITLE
use a mocha reporter that doesn't blank the screen

### DIFF
--- a/build.js
+++ b/build.js
@@ -35,7 +35,7 @@ if (!force) {
 		console.log('`'+ modPath+ '` exists; testing');
 		 
 		var mocha = new Mocha({
-		    reporter: 'min',
+		    reporter: 'dot',
 		    ui: 'bdd',
 		    timeout: 999999
 		});


### PR DESCRIPTION
Currently the build step uses the `min` reporter which blanks the screen which is unexpected and confusing.

This switches to the `dot` reporter which prints a single dot for each test and does not blank the screen.
