### PR TITLE
added ENV option to skip the build tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ Output will be saved with the same name as input SASS file into the current work
       --include-path     Path to look for @import-ed files                      [default: cwd]
       --help, -h         Print usage info
 
+## Post-install Build
+
+Install runs a series of Mocha tests to see if your machine can use the pre-built `libsass` which will save some time during install. If any tests fail it will build from source.
+
+If you know the pre-built version will work and do not want to wait for the tests to run you can skip the tests by setting the environment variable `SKIP_NODE_SASS_TESTS` to true.
+
+      SKIP_NODE_SASS_TESTS=true npm install
+
 ## Contributors
 Special thanks to the following people for submitting patches:
 
@@ -153,6 +161,7 @@ Dean Mao
 Brett Wilkins
 litek
 gonghao
+Dylan Greene
 
 ### Note on Patches/Pull Requests
 

--- a/build.js
+++ b/build.js
@@ -29,7 +29,7 @@ if (!{ia32: true, x64: true, arm: true}.hasOwnProperty(arch)) {
 
 // Test for pre-built library
 var modPath = platform + '-' + arch + '-v8-' + v8;
-if (!force) {
+if (!force && !process.env.SKIP_NODE_SASS_TESTS) {
 	try {
 		fs.statSync(path.join(__dirname, 'bin', modPath, 'binding.node'));
 		console.log('`'+ modPath+ '` exists; testing');


### PR DESCRIPTION
Having the tests run during the build step is a great way to know if it will work. Our problem is that we install node-sass very frequently and we already know the binary should work for us. We think this will save a couple seconds in our build time.

We don't use the `-f` option because it puts `npm` into `force` mode for all node modules being installed which is not what we want.
