### PR TITLE
Changed order of terminal commands for binaries rebuilding

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ Check out the project:
 
     git clone https://github.com/andrew/node-sass.git
     cd node-sass
-    npm install
-    npm install -g node-gyp
     git submodule init
     git submodule update
+    npm install
+    npm install -g node-gyp
     node-gyp rebuild
 
 Replace the prebuild binary with your newly generated one


### PR DESCRIPTION
You've to initialise and update submodules before running `npm install`, because it automatically runs building script.
