### PR TITLE
use NAN for Node 0.8->0.11+ compatibility

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -28,6 +28,9 @@
         'libsass/to_string.cpp',
         'libsass/units.cpp'
       ],
+      'include_dirs': [
+        '<!(node -e \'require("nan")\')'
+      ],
       'cflags!'   : [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],
       'cflags_cc' : [ '-fexceptions', '-frtti' ],

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "optimist": "0.6.x",
     "node-watch": "0.3.x",
     "mocha": "1.13.x",
-    "chalk": "~0.3.0"
+    "chalk": "~0.3.0",
+    "nan": "~0.6.0"
   }
 }

--- a/sass_context_wrapper.cpp
+++ b/sass_context_wrapper.cpp
@@ -13,6 +13,9 @@ extern "C" {
   {
     if (ctx_w->ctx) sass_free_context(ctx_w->ctx);
 
+    delete ctx_w->callback;
+    delete ctx_w->errorCallback;
+
     free(ctx_w);
   }
 
@@ -24,6 +27,9 @@ extern "C" {
   void sass_free_file_context_wrapper(sass_file_context_wrapper* ctx_w)
   {
     if (ctx_w->ctx) sass_free_file_context(ctx_w->ctx);
+
+    delete ctx_w->callback;
+    delete ctx_w->errorCallback;
 
     free(ctx_w);
   }

--- a/sass_context_wrapper.h
+++ b/sass_context_wrapper.h
@@ -1,5 +1,5 @@
 #include "libsass/sass_interface.h"
-#include <node.h>
+#include <nan.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -8,8 +8,8 @@ extern "C" {
 struct sass_context_wrapper {
   sass_context* ctx;
   uv_work_t request;
-  v8::Persistent<v8::Function> callback;
-  v8::Persistent<v8::Function> errorCallback;
+  NanCallback* callback;
+  NanCallback* errorCallback;
 };
 
 struct sass_context_wrapper*      sass_new_context_wrapper(void);
@@ -18,8 +18,8 @@ void sass_free_context_wrapper(struct sass_context_wrapper* ctx);
 struct sass_file_context_wrapper {
   sass_file_context* ctx;
   uv_work_t request;
-  v8::Persistent<v8::Function> callback;
-  v8::Persistent<v8::Function> errorCallback;
+  NanCallback* callback;
+  NanCallback* errorCallback;
 };
 
 struct sass_file_context_wrapper*      sass_new_file_context_wrapper(void);


### PR DESCRIPTION
Node 0.11 and onwards uses the new V8 which has huge breaking API changes. NAN is designed to make it easy to support V8 and Node across versions 0.8 to 0.11 and onwards without the need for branching macros. NAN is keeping up-to-date as newer versions of Node 0.11 are released and new breaking changes come upstream from V8.

This PR adds NAN support for compiling against the latest Node 0.11; tests all pass. Would be good to get this in npm before the impending 0.12 release.

Let me know if you have any questions.
