### PR TITLE
Fix binding.gyp / NAN quoting for Windows build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -29,7 +29,7 @@
         'libsass/units.cpp'
       ],
       'include_dirs': [
-        '<!(node -e \'require("nan")\')'
+        '<!(node -e "require(\'nan\')")'
       ],
       'cflags!'   : [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],


### PR DESCRIPTION
sorry for the trivial PR but my NAN PR had the wrong quoting in binding.gyp; windows likes it to be a certain way and a compile will fail if it's wrong.
