### PR TITLE
Initial support for the new source map feature of libsass

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,6 +14,9 @@ var optimist = require('optimist')
     describe: 'Include debug info in output (none|normal|map)',
     'default': 'none'
   })
+  .options('source-map', {
+    describe: 'Emit source map'
+  })
   .options('include-path', {
     describe: 'Path to look for @import-ed files',
     'default': cwd
@@ -97,6 +100,16 @@ exports = module.exports = function(args) {
   options.sourceComments = argv['source-comments'];
   if (Array.isArray(options.sourceComments)) {
     options.sourceComments = options.sourceComments[0];
+  }
+
+  // set source map file and set sourceComments to 'map'
+  if (argv['source-map']) {
+    options.sourceComments = 'map';
+    if (argv['source-map'] === true) {
+      options.sourceMap = outFile + '.map';
+    } else {
+      options.sourceMap = path.resolve(cwd, argv['source-map']);
+    }
   }
 
   if (argv.w) {

--- a/lib/render.js
+++ b/lib/render.js
@@ -9,7 +9,15 @@ function render(options, emitter) {
     includePaths: options.includePaths,
     outputStyle: options.outputStyle,
     sourceComments: options.sourceComments,
-    success: function(css) {
+    sourceMap: options.sourceMap,
+    success: function(css, sourceMap) {
+
+      var todo = 1;
+      var done = function() {
+        if (--todo <= 0) {
+          emitter.emit('done');
+        }
+      };
 
       emitter.emit('warn', chalk.green('Rendering Complete, saving .css file...'));
 
@@ -17,7 +25,18 @@ function render(options, emitter) {
         if (err) { return emitter.emit('error', chalk.red('Error: ' + err)); }
         emitter.emit('warn', chalk.green('Wrote CSS to ' + options.outFile));
         emitter.emit('write', err, options.outFile, css);
+        done();
       });
+
+      if (options.sourceMap) {
+        todo++;
+        fs.writeFile(options.sourceMap, sourceMap, function(err) {
+          if (err) {return emitter.emit('error', chalk.red('Error' + err)); }
+          emitter.emit('warn', chalk.green('Wrote Source Map to ' + options.sourceMap));
+          emitter.emit('write-source-map', err, options.sourceMap, sourceMap);
+          done();
+        });
+      }
 
       if (options.stdout) {
         emitter.emit('log', css);

--- a/sass.js
+++ b/sass.js
@@ -68,9 +68,8 @@ exports.render = function(options) {
   options.error = options.error || function(){};
 
   if (options.file !== undefined && options.file !== null) {
-    return binding.renderFile(options.file, options.success, options.error, newOptions.paths.join(path.delimiter), newOptions.style, newOptions.comments);
+    return binding.renderFile(options.file, options.success, options.error, newOptions.paths.join(path.delimiter), newOptions.style, newOptions.comments, options.sourceMap);
   }
-
   //Assume data is present if file is not. binding/libsass will tell the user otherwise!
   return binding.render(options.data, options.success, options.error, newOptions.paths.join(path.delimiter), newOptions.style);
 };

--- a/test/cli.js
+++ b/test/cli.js
@@ -103,4 +103,41 @@ describe('cli', function() {
     });
   });
 
+  it('should compile with the --source-map option', function(done){
+    var emitter = cli([path.join(__dirname, 'sample.scss'), '--source-map']);
+    emitter.on('error', done);
+    emitter.on('write-source-map', function(err, file) {
+      assert.equal(file, path.join(__dirname, '../sample.css.map'));
+      fs.exists(file, function(exists) {
+        assert(exists);
+      });
+    });
+    emitter.on('done', function() {
+      fs.unlink(path.join(__dirname, '../sample.css.map'), function() {
+        fs.unlink(path.join(__dirname, '../sample.css'), function() {
+          done();
+        });
+      });
+    });
+  });
+
+  it('should compile with the --source-map option with specific filename', function(done){
+    var emitter = cli([path.join(__dirname, 'sample.scss'), '--source-map', path.join(__dirname, '../sample.map')]);
+    emitter.on('error', done);
+    emitter.on('write-source-map', function(err, file) {
+      assert.equal(file, path.join(__dirname, '../sample.map'));
+      fs.exists(file, function(exists) {
+        assert(exists);
+      });
+    });
+    emitter.on('done', function() {
+      fs.unlink(path.join(__dirname, '../sample.map'), function() {
+        fs.unlink(path.join(__dirname, '../sample.css'), function() {
+          done();
+        });
+      });
+    });
+  });
+
+
 });


### PR DESCRIPTION
For a little while libsass has source maps support. This is a start enabling that feature through node-sass.

As for now only the `RenderFile` is changed, because that's the one used by the CLI. I can change the other methods if everthing is ok.
