### PR TITLE
Smart defaults when only source-comment=map used

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -109,6 +109,11 @@ exports = module.exports = function(args) {
     options.sourceComments = options.sourceComments[0];
   }
 
+  // Set the sourceMap path if the sourceComment was 'map', but set source-map was missing
+  if (options.sourceComments === 'map' && !argv['source-map']) {
+    argv['source-map'] = true;
+  }
+
   // set source map file and set sourceComments to 'map'
   if (argv['source-map']) {
     options.sourceComments = 'map';

--- a/test/cli.js
+++ b/test/cli.js
@@ -138,4 +138,22 @@ describe('cli', function() {
     });
   });
 
+  it('should compile a sourceMap if --source-comments="map", but the --source-map option is excluded', function(done){
+    var emitter = cli([path.join(__dirname, 'sample.scss'), '--source-comments', 'map']);
+    emitter.on('error', done);
+    emitter.on('write-source-map', function(err, file) {
+      assert.equal(file, path.join(__dirname, '../sample.css.map'));
+      fs.exists(file, function(exists) {
+        assert(exists);
+      });
+    });
+    emitter.on('done', function() {
+      fs.unlink(path.join(__dirname, '../sample.css.map'), function() {
+        fs.unlink(path.join(__dirname, '../sample.css'), function() {
+          done();
+        });
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
Instead of just emitting `/*# sourceMappingURL=undefined */`, act like `--source-map` option was passed and create the map file
