### PR TITLE
Add Node 0.11 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.11"
+
 after_success:
   - npm run-script coverage


### PR DESCRIPTION
Now that Travis bumped to 0.11.10, we can rebuild successfully.
