### PR TITLE
Fix sourceMappingURL

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -70,7 +70,7 @@ void extractOptions(_NAN_METHOD_ARGS, void* cptr, sass_context_wrapper* ctx_w, b
     if (source_comments == SASS_SOURCE_COMMENTS_MAP) {
       String::AsciiValue dstr(args[7]);
       ctx->source_map_file = new char[strlen(*dstr)+1];
-      ctx->source_map_file = *dstr;
+      strcpy((char*) ctx->source_map_file, *dstr);
     }
   } else {
     sass_context *ctx = (sass_context*)cptr;

--- a/test/source_map_spec.js
+++ b/test/source_map_spec.js
@@ -1,0 +1,24 @@
+/*jshint multistr:true */
+var sass = require('../sass');
+var assert = require('assert');
+
+var sampleFilename = require('path').resolve(__dirname, 'sample.scss');
+
+describe("compile source maps", function() {
+  it("should compile file with source map URL", function(done) {
+    var mapFileName = 'sample.css.map';
+    sass.render({
+      file: sampleFilename,
+      sourceComments: 'map',
+      sourceMap: mapFileName,
+      success: function (css, map) {
+        assert.ok(css.indexOf('sourceMappingURL=' + mapFileName) !== -1);
+        assert.ok(map.indexOf('sample.scss') !== -1);
+        done();
+      },
+      error: function (error) {
+        done(error);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Broken from 04dd6f2268

Simple fix to cast the const pointer to a non-const pointer. String
seems to still need to be copied.

Add a very simple test to test for source maps, very similar to the test in grunt-sass.
