### PR TITLE
npm install fails if libsass is not published

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "url": "git://github.com/andrew/node-sass.git"
   },
   "scripts": {
+    "preinstall": "if [ ! -d 'libsass' ]; then git clone git://github.com/hcatlin/libsass.git; fi",
     "install": "node build.js",
     "test": "mocha test",
     "coverage": "bash scripts/coverage.sh",


### PR DESCRIPTION
If you run an "npm publish" and libsass isn't included, then people doing an "npm install node-sass" get errrors.

See https://github.com/andrew/node-sass/issues/244

As a hotfix, you can include "git clone https://github.com/hcatlin/libsass" to the install command. This only works if end users have git installed (which might not be true for _all_ node users).  The better solution is ensuring libsass is included whenever you run "npm publish".

``` bash
# make 2 test directories
mkdir ~/node-sass-test1 && mkdir ~/node-sass-test2

# this test errors
cd ~/node-sass-test1
npm install git://github.com/andrew/node-sass.git

# this test works because libsass exists (after cloning)
cd ~/node-sass-test2
npm install git://github.com/skratchdot/node-sass.git
```
