### PR TITLE
Restore path.delimiter use for depreciateRender

### DIFF
--- a/sass.js
+++ b/sass.js
@@ -57,12 +57,12 @@ var deprecatedRender = function(css, callback, options) {
   var oldCallback = function(css) {
     callback(null, css);
   };
-  return binding.render(css, options.imagePath, oldCallback, errCallback, options.paths.join(':'), options.style, options.comments);
+  return binding.render(css, options.imagePath, oldCallback, errCallback, options.paths.join(path.delimiter), options.style, options.comments);
 };
 
 var deprecatedRenderSync = function(css, options) {
   options = prepareOptions(options);
-  return binding.renderSync(css, options.imagePath, options.paths.join(':'), options.style, options.comments);
+  return binding.renderSync(css, options.imagePath, options.paths.join(path.delimiter), options.style, options.comments);
 };
 
 exports.render = function(options) {


### PR DESCRIPTION
This is required for non-unix platform path separators to function

Think this got reverted from @LaurentGoderre's previous fixes, and it may address a regression from #182
