### PR TITLE
Cleaner detection of bindings with better error handling.

### DIFF
--- a/sass.js
+++ b/sass.js
@@ -1,23 +1,26 @@
-var binding;
-var fs = require('fs');
 var path = require('path');
 
-var v8 = 'v8-' + /[0-9]+\.[0-9]+/.exec(process.versions.v8)[0];
-var modPath = path.join(__dirname, 'bin', process.platform + '-' + process.arch + '-' + v8, 'binding');
-try {
-  if (fs.realpathSync(__dirname + '/build')) {
-    // use the build version if it exists
-    binding = require(__dirname + '/build/Release/binding');
+function requireBinding() {
+  var fs = require('fs');
+  var v8 = 'v8-' + /[0-9]+\.[0-9]+/.exec(process.versions.v8)[0];
+
+  var candidates = [
+    [__dirname, 'build', 'Release', 'obj.target', 'binding.node'],
+    [__dirname, 'bin', process.platform + '-' + process.arch + '-' + v8, 'binding.node'],
+  ];
+
+  for (var i = 0, l = candidates.length; i < l; i++) {
+    var candidate = path.join.apply(path.join, candidates[i]);
+
+    if (fs.existsSync(candidate)) {
+      return require(candidate);
+    }
   }
-} catch (e) {
-  try {
-    fs.realpathSync(modPath + '.node');
-    binding = require(modPath);
-  } catch (ex) {
-    // No binary!
-    throw new Error('`'+ modPath + '.node` is missing. Try reinstalling `node-sass`?');
-  }
+
+  throw new Error('`libsass` bindings not found. Try reinstalling `node-sass`?');
 }
+
+var binding = requireBinding();
 
 var SASS_OUTPUT_STYLE = {
     nested: 0,


### PR DESCRIPTION
I found this issue while debugging why `node-sass` wouldn't work on my 32-bit Debian 6 install. The current implementation caught all exceptions and reported the same error whether or not the file was actually there. The proposed change makes the file's existence check explicit and then calls `require`. Exceptions with `require` are intentionally not handled.

Before the patch:

```
$ npm test

[...]

/root/jano/node-sass/sass.js:18
    throw new Error('`'+ modPath + '.node` is missing. Try reinstalling `node-
          ^
Error: `/root/jano/node-sass/bin/linux-ia32-v8-3.22/binding.node` is missing. Try reinstalling `node-sass`?
```

After the patch:

```
$ npm test

[...]

module.js:349
  Module._extensions[extension](this, filename);
                               ^
Error: /root/jano/node-sass/build/Release/obj.target/binding.node: undefined symbol: _ZN2v84NullEv
```
