### PR TITLE
Fix ShellJS resolutions on Windows

### DIFF
--- a/scripts/lint
+++ b/scripts/lint
@@ -5,4 +5,7 @@
 
 require("shelljs/make");
 
-exec("jshint .");
+var path = require("path");
+var JSHINT_BIN = ["node_modules", ".bin", "jshint"].join(path.sep);
+
+exec(JSHINT_BIN + " .");

--- a/scripts/test
+++ b/scripts/test
@@ -5,4 +5,7 @@
 
 require("shelljs/make");
 
-exec("mocha test");
+var path = require("path");
+var mocha = ["node_modules", ".bin", "mocha"].join(path.sep);
+
+exec(mocha + " test");


### PR DESCRIPTION
https://github.com/arturadib/shelljs/issues/41

This was previously masked during my testing because I had these modules installed globally. The coverage script already does this for the same reason
