### PR TITLE
don't prepareOptions twice in `renderFile()`

### DIFF
--- a/sass.js
+++ b/sass.js
@@ -131,19 +131,18 @@ exports.renderSync = function(options) {
 /**
   Same as `render()` but with an extra `outFile` property in `options` and writes
   the CSS and sourceMap (if requested) to the filesystem.
-  
+
   `options.sourceMap` can be used to specify that the source map should be saved:
-  
+
   - If falsy the source map will not be saved
   - If `options.sourceMap === true` the source map will be saved to the
   standard location of `options.file + '.map'`
-  - Else `options.sourceMap` specifies the path (relative to the `outFile`) 
+  - Else `options.sourceMap` specifies the path (relative to the `outFile`)
   where the source map should be saved
  */
 exports.renderFile = function(options) {
   var success;
 
-  options = prepareOptions(options);
   success = options.success;
   if (options.sourceMap === true) {
     options.sourceMap = path.basename(options.outFile) + '.map';

--- a/test/include_path.scss
+++ b/test/include_path.scss
@@ -1,4 +1,4 @@
-@import "lib/vars";
-@import "functions/colorBlue";
+@import "vars";
+@import "colorBlue";
 
 body { background: $color; color: colorBlue(); }

--- a/test/test.js
+++ b/test/test.js
@@ -104,6 +104,22 @@ describe('compile file with include paths', function(){
       }
     });
   });
+
+  it('should compile with renderFile', function(done) {
+    var testFile = path.resolve(__dirname, 'tmp-include-path.css');
+    sass.renderFile({
+      file: path.resolve(__dirname, 'include_path.scss'),
+      outFile: testFile,
+      includePaths: [path.resolve(__dirname, 'lib'), path.resolve(__dirname, 'functions')],
+      success: function () {
+        done(assert.equal(fs.readFileSync(testFile, 'utf8'), 'body {\n  background: red;\n  color: #0000fe; }\n'));
+        fs.unlinkSync(testFile);
+      },
+      error: function (error) {
+        done(error);
+      }
+    });
+  });
 });
 
 describe('compile file with image path', function(){


### PR DESCRIPTION
Doing it twice, once in `renderFile` and then in `render` makes it lose some options.

Fixes sindresorhus/grunt-sass#95

I also made the `render()` test actually test includePaths as the current test was faulty.
