### PR TITLE
don't modify the user supplied options object directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "mocha": "~1.18.2",
     "nan": "~1.0.0",
     "node-watch": "~0.3.4",
+    "object-assign": "^0.3.1",
     "optimist": "~0.6.1",
     "shelljs": "~0.2.6",
     "sinon": "~1.9.1"

--- a/sass.js
+++ b/sass.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var fs = require('fs');
+var assign = require('object-assign');
 
 function requireBinding() {
   var v8 = 'v8-' + /[0-9]+\.[0-9]+/.exec(process.versions.v8)[0];
@@ -110,6 +111,7 @@ exports.render = function(options) {
     return deprecatedRender.apply(this, arguments);
   }
 
+  options = assign({}, options);
   options = prepareOptions(options);
   options.file? binding.renderFile(options) : binding.render(options);
 };
@@ -121,6 +123,7 @@ exports.renderSync = function(options) {
     return deprecatedRenderSync.apply(this, arguments);
   }
 
+  options = assign({}, options);
   options = prepareOptions(options);
   output = options.file? binding.renderFileSync(options) : binding.renderSync(options);
   finishStats(options.stats);
@@ -143,6 +146,7 @@ exports.renderSync = function(options) {
 exports.renderFile = function(options) {
   var success;
 
+  options = assign({}, options);
   success = options.success;
   if (options.sourceMap === true) {
     options.sourceMap = path.basename(options.outFile) + '.map';


### PR DESCRIPTION
this can cause unintended side-effects if the user uses the same options object for multiple sass calls.

_note: i could have put it in `prepareOption`, but need to have it in `renderFile` directly anyways, so would just have saved one instance. clearer this way._
