### PR TITLE
Make sourceMap sources paths relative to the sourceMap location.

### DIFF
--- a/sass.js
+++ b/sass.js
@@ -132,6 +132,14 @@ exports.renderSync = function(options) {
   return output;
 };
 
+var makeSourceMapUrlsRelative = function (sourceMap, dir) {
+    var map = JSON.parse(sourceMap);
+    map.sources = map.sources.map(function (source) {
+        return path.relative(dir, source);
+    });
+    return JSON.stringify(map);
+};
+
 /**
   Same as `render()` but with an extra `outFile` property in `options` and writes
   the CSS and sourceMap (if requested) to the filesystem.
@@ -162,6 +170,7 @@ exports.renderFile = function(options) {
       if (options.sourceMap) {
         dir = path.dirname(options.outFile);
         sourceMapFile = path.resolve(dir, options.sourceMap);
+        sourceMap = makeSourceMapUrlsRelative(sourceMap, path.dirname(sourceMapFile));
         fs.writeFile(sourceMapFile, sourceMap, function(err) {
           if (err) {
             return options.error(err);

--- a/test/test.js
+++ b/test/test.js
@@ -260,6 +260,26 @@ describe('render to file', function() {
     });
   });
 
+  it('should save source paths relative to the sourceMap file', function(done) {
+    var includedFilesFile = path.resolve(__dirname, 'included_files.scss');
+    var relativeOutFile = path.resolve(__dirname, 'some_path/out.scss');
+    sass.renderFile({
+      file: includedFilesFile,
+      outFile: relativeOutFile,
+      sourceMap: true,
+      success: function (cssFile, sourceMapFile) {
+        var mapObject = JSON.parse(filesWritten[sourceMapFile]);
+        assert.ok(mapObject.sources.indexOf('../included_files.scss') > -1);
+        assert.ok(mapObject.sources.indexOf('../sample.scss') > -1);
+        assert.ok(mapObject.sources.indexOf('../image_path.scss') > -1);
+        done();
+      },
+      error: function (error) {
+        done(error);
+      }
+    });
+  });
+
 });
 
 describe('precision support', function() {


### PR DESCRIPTION
According to [the SourceMap spec](https://docs.google.com/a/ff0000.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit?pli=1#heading=h.75yo6yoyk7x5), the sources should be relative to the sourceMap location.

> Resolving Sources
> If the sources are not absolute URLs after prepending of the “sourceRoot”, the sources are resolved relative to the SourceMap (like resolving script src in a html document).

Because `renderFile` is saving the sourceMap to a different location than what `libsass` is aware of, the sources paths need to be updated.

I think this should solve #341.
