### PR TITLE
sourceMaps non-string option while sourceComments='map' causes crash

### DIFF
--- a/sass.js
+++ b/sass.js
@@ -43,6 +43,7 @@ var prepareOptions = function (options) {
   var error;
   var stats;
   var sourceComments;
+  var sourceMap;
 
   options = options || {};
   success = options.success;
@@ -53,6 +54,11 @@ var prepareOptions = function (options) {
   if (options.sourceMap && !sourceComments) {
     sourceComments = 'map';
   }
+  sourceMap = options.sourceMap;
+  if (typeof sourceMap !== 'string' && sourceComments === 'map') {
+    sourceMap = '';
+  }
+
   prepareStats(options, stats);
 
   return {
@@ -64,7 +70,7 @@ var prepareOptions = function (options) {
     style: SASS_OUTPUT_STYLE[options.output_style || options.outputStyle] || 0,
     comments: SASS_SOURCE_COMMENTS[sourceComments] || 0,
     stats: stats,
-    sourceMap: options.sourceMap,
+    sourceMap: sourceMap,
     precision: parseInt(options.precision) || 5,
     success: function onSuccess(css, sourceMap) {
       finishStats(stats, sourceMap);


### PR DESCRIPTION
Finally fixes #337, the bug is caused by the grunt-sass library setting `sourceComments` to `map` while leaving `sourceMaps` as `undefined`. The way I chose to fix this was to set `sourceMaps` to `''` as that seems to be an acceptable way to pass this option to libsass (tbh I don't know what it ends up doing with it but I can confirm it works and I think the tests might also be doing this).

Also, I changed the binary loader section and removed the _obj.target_ directory as the buillds end up being linked into the directory above that and it should be the proper place to load it from. I also added the _Debug_ directory as that's where they end upwith `--debug` and I needed that to get some lldb line number magic out of this crash.
