### PR TITLE
Binding: Send output path to upstream (#379)

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -50,6 +50,7 @@ void ExtractOptions(Local<Value> optionsValue, void* cptr, sass_context_wrapper*
   if (isFile) {
     sass_file_context* ctx = (sass_file_context*) cptr;
     ctx->input_path = CreateString(options->Get(NanNew("file")));
+    ctx->output_path = CreateString(options->Get(NanNew("outFile")));
     ctx->options.image_path = CreateString(options->Get(NanNew("imagePath")));
     ctx->options.output_style = options->Get(NanNew("style"))->Int32Value();
     ctx->options.source_comments = source_comments = options->Get(NanNew("comments"))->Int32Value();
@@ -61,6 +62,7 @@ void ExtractOptions(Local<Value> optionsValue, void* cptr, sass_context_wrapper*
   } else {
     sass_context* ctx = (sass_context*) cptr;
     ctx->source_string = CreateString(options->Get(NanNew("data")));
+    ctx->output_path = CreateString(options->Get(NanNew("outFile")));
     ctx->options.image_path = CreateString(options->Get(NanNew("imagePath")));
     ctx->options.output_style = options->Get(NanNew("style"))->Int32Value();
     ctx->options.source_comments = source_comments = options->Get(NanNew("comments"))->Int32Value();

--- a/lib/render.js
+++ b/lib/render.js
@@ -12,6 +12,7 @@ function render(options, emitter) {
     sourceComments: options.sourceComments,
     sourceMap: options.sourceMap,
     precision: options.precision,
+    outFile: options.outFile,
     success: function(css, sourceMap) {
 
       var todo = 1;

--- a/sass_context_wrapper.cpp
+++ b/sass_context_wrapper.cpp
@@ -7,6 +7,7 @@ extern "C" {
 
   void free_context(sass_context* ctx) {
     delete[] ctx->source_string;
+    delete[] ctx->output_path;
     delete[] ctx->options.include_paths;
     delete[] ctx->options.image_path;
     sass_free_context(ctx);


### PR DESCRIPTION
Fixes #379.

Sorry for the nuisance; this was reverted by the last commit.
