### PR TITLE
Code: Fixed another segmentation fault

### DIFF
--- a/sass_context_wrapper.cpp
+++ b/sass_context_wrapper.cpp
@@ -7,7 +7,6 @@ extern "C" {
 
   void free_context(sass_context* ctx) {
     delete[] ctx->source_string;
-    delete[] ctx->output_path;
     delete[] ctx->options.include_paths;
     delete[] ctx->options.image_path;
     sass_free_context(ctx);
@@ -15,7 +14,6 @@ extern "C" {
 
   void free_file_context(sass_file_context* fctx) {
     delete[] fctx->input_path;
-    delete[] fctx->output_path;
     delete[] fctx->options.include_paths;
     delete[] fctx->options.image_path;
     sass_free_file_context(fctx);


### PR DESCRIPTION
With this, the travis-ci build doesn't throw seg-fault. :relaxed: 

There are still two test cases failing on Ubuntu and one on Windows.

@mgreter, can you reproduce these? In Windows [this test](https://github.com/sass/node-sass/blob/26c1bf31be8e412f463b15b2282b5aa1ae08cd28/test/test.js#L263-L283) fails as upstream returns:

``` json
  sources:
   [ '..\\included_files.scss',
     '..\\sample.scss',
     '..\\image_path.scss' ],
```

instead of : 

``` json
  sources:
   [ '../included_files.scss',
     '../sample.scss',
     '../image_path.scss' ],
```

In Ubuntu, these [two tests fail](https://github.com/sass/node-sass/blob/26c1bf31be8e412f463b15b2282b5aa1ae08cd28/test/test.js#L223-L261) owing to the fact that upstream puts this comment `/*# sourceMappingURL=../out.css.map */` in CSS instead of `/*# sourceMappingURL=out.css.map */`.
