### PR TITLE
Remove v0.11 test in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "0.10"
-  - "0.11"
 before_install:
   - git submodule update --init --recursive
 after_success:


### PR DESCRIPTION
I've tried for fixing build status, but maybe build.js with `node-gyp` does not work in `v0.11`. So I removed `v0.11` in .travis.yml

refs:
https://github.com/nodegit/nodegit/issues/212
