### PR TITLE
SourceMaps: Don't fix map generated by upstream

### DIFF
--- a/sass.js
+++ b/sass.js
@@ -140,14 +140,6 @@ exports.renderSync = function(options) {
   return output;
 };
 
-var makeSourceMapUrlsRelative = function (sourceMap, dir) {
-    var map = JSON.parse(sourceMap);
-    map.sources = map.sources.map(function (source) {
-        return path.relative(dir, source);
-    });
-    return JSON.stringify(map);
-};
-
 /**
   Same as `render()` but with an extra `outFile` property in `options` and writes
   the CSS and sourceMap (if requested) to the filesystem.
@@ -166,7 +158,7 @@ exports.renderFile = function(options) {
   options = assign({}, options);
   success = options.success;
   if (options.sourceMap === true) {
-    options.sourceMap = path.basename(options.outFile) + '.map';
+    options.sourceMap = options.outFile + '.map';
   }
   options.success = function(css, sourceMap) {
     fs.writeFile(options.outFile, css, function(err) {
@@ -178,7 +170,6 @@ exports.renderFile = function(options) {
       if (options.sourceMap) {
         dir = path.dirname(options.outFile);
         sourceMapFile = path.resolve(dir, options.sourceMap);
-        sourceMap = makeSourceMapUrlsRelative(sourceMap, path.dirname(sourceMapFile));
         fs.writeFile(sourceMapFile, sourceMap, function(err) {
           if (err) {
             return options.error(err);


### PR DESCRIPTION
This fixes the tests for both Windows and Linux; when https://github.com/sass/libsass/pull/477 is applied.

Note: the sourcemap filename should be the complete path when using node-sass from downstream.

Note 2: On Windows, however, MSVCR throws exception on `npm install` but continues. `node-gyp rebuild` runs just fine. After that its all ok.
