### PR TITLE
Add new duo.js extension duo-sass to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ Heavily inspired by <https://github.com/LearnBoost/stylus>
 
 [@jking90](https://github.com/jking90) wrote a [DocPad](http://docpad.org/) plugin that compiles `.scss` files using node-sass: <https://github.com/jking90/docpad-plugin-nodesass>
 
+## Duo.js extension
+
+[@stephenway](https://github.com/stephenway) has created an extension that transpiles Sass to CSS using node-sass with [duo.js](http://duojs.org/)
+<https://github.com/stephenway/duo-sass>
+
 ## Grunt extension
 
 [@sindresorhus](https://github.com/sindresorhus/) has created a set of grunt tasks based on node-sass: <https://github.com/sindresorhus/grunt-sass>


### PR DESCRIPTION
I'd like to list my extension so people who like using node-sass know they can now use it with duo.
