### PR TITLE
SourceMap: Resolve path w.r.t output directory

### DIFF
--- a/sass.js
+++ b/sass.js
@@ -57,6 +57,8 @@ var prepareOptions = function (options) {
   sourceMap = options.sourceMap;
   if (typeof sourceMap !== 'string' && sourceComments === 'map') {
     sourceMap = '';
+  } else if (options.outFile && sourceMap) {
+    sourceMap = path.resolve(path.dirname(options.outFile), sourceMap);
   }
 
   prepareStats(options, stats);


### PR DESCRIPTION
With this, the last failing test passes on Windows.

Thanks @mgreter for insights. We should close the libsass PR: https://github.com/sass/libsass/pull/477.

@andrew, the only test failing on both 0.10 and 0.11 is stdin related, as discussed here: https://github.com/sass/node-sass/pull/410#issuecomment-54213682
