### PR TITLE
Fix stdin

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -53,9 +53,11 @@ var yargs = require('yargs')
     type: 'string',
     alias: 'help'
   })
-  .check(function(argv){
-    if (!argv.stdout && argv.o === undefined && argv._.length === 0) { return false; }
+  .check(function(argv) {
     if (argv.help) { return true; }
+    if (!argv._.length && (process.stdin.isTTY || process.env.isTTY)) {
+      return false;
+    }
   });
 
 // throttle function, used so when multiple files change at the same time
@@ -63,6 +65,7 @@ var yargs = require('yargs')
 function throttle(fn) {
   var timer;
   var args = Array.prototype.slice.call(arguments, 1);
+
   return function() {
     var self = this;
     clearTimeout(timer);
@@ -76,110 +79,106 @@ function isSassFile(file) {
   return file.match(/\.(sass|scss)/);
 }
 
-exports = module.exports = function(args) {
-  var argv = yargs.parse(args);
-
-  if (argv.help) {
-    yargs.showHelp();
-    process.exit(0);
-    return;
-  }
-
-  var emitter = new Emitter();
-
-  emitter.on('error', function(err){
-    console.error(err);
-    process.exit(1);
-  });
-
-  var options = {
-    stdout: argv.stdout,
-    omitSourceMapUrl: argv['omit-source-map-url']
-  };
-
-  var inFile = options.inFile = argv._[0];
-  var outFile = options.outFile = argv.o || argv._[1];
-
-  if (!outFile) {
-    var suffix = '.css';
-    if (/\.css$/.test(inFile)) {
-      suffix = '';
-    }
-    outFile = options.outFile = path.join(cwd, path.basename(inFile, '.scss') + suffix);
-  }
-
-  // make sure it's an array.
-  options.includePaths = argv['include-path'];
+function run(options, emitter) {
   if (!Array.isArray(options.includePaths)) {
     options.includePaths = [options.includePaths];
   }
 
-  // include the image path.
-  options.imagePath = argv['image-path'];
-
-  // if it's an array, make it a string
-  options.outputStyle = argv['output-style'];
   if (Array.isArray(options.outputStyle)) {
     options.outputStyle = options.outputStyle[0];
   }
 
-  // if it's an array, make it a string
-  options.sourceComments = argv['source-comments'];
   if (Array.isArray(options.sourceComments)) {
     options.sourceComments = options.sourceComments[0];
   }
 
-  // Set the sourceMap path if the sourceComment was 'map', but set source-map was missing
-  if (options.sourceComments === 'map' && !argv['source-map']) {
-    argv['source-map'] = true;
+  if (options.sourceComments === 'map' && !options.sourceMap) {
+    options.sourceMap = true;
   }
 
-  // set source map file and set sourceComments to 'map'
-  if (argv['source-map']) {
+  if (options.sourceMap) {
     options.sourceComments = 'map';
-    if (argv['source-map'] === true) {
-      options.sourceMap = outFile + '.map';
+
+    if (options.sourceMap === true) {
+      options.sourceMap = options.dest + '.map';
     } else {
-      options.sourceMap = path.resolve(cwd, argv['source-map']);
+      options.sourceMap = path.resolve(cwd, options.sourceMap);
     }
   }
 
-  options.precision = argv.precision;
-
-  if (argv.w) {
-
-    var watchDir = argv.w;
+  if (options.watch) {
+    var throttledRender = throttle(render, options, emitter);
+    var watchDir = options.watch;
 
     if (watchDir === true) {
       watchDir = [];
     } else if (!Array.isArray(watchDir)) {
       watchDir = [watchDir];
     }
-    watchDir.push(inFile);
 
-    var throttledRender = throttle(render, options, emitter);
+    watchDir.push(options.src);
 
-    watch(watchDir, function(file){
+    watch(watchDir, function(file) {
       emitter.emit('warn', '=> changed: '.grey + file.blue);
+
       if (isSassFile(file)) {
         throttledRender();
       }
     });
 
     throttledRender();
-
   } else {
-    if (inFile === undefined && args.length > 0) {
-      stdin(function(data){
-        options.data = data.toString().trim();
-        render(options, emitter);
-      });
-    } else {
-      render(options, emitter);
+    render(options, emitter);
+  }
+}
+
+module.exports = function(args) {
+  var argv = yargs.parse(args);
+  var emitter = new Emitter();
+  var options = {
+    imagePath: argv['image-path'],
+    includePaths: argv['include-path'],
+    omitSourceMapUrl: argv['omit-source-map-url'],
+    outputStyle: argv['output-style'],
+    precision: argv.precision,
+    sourceComments: argv['source-comments'],
+    sourceMap: argv['source-map'],
+    stdout: argv.stdout,
+    watch: argv.w
+  };
+
+  if (argv.help) {
+    yargs.showHelp();
+    process.exit();
+    return;
+  }
+
+  emitter.on('error', function(err) {
+    console.error(err);
+    process.exit(1);
+  });
+
+  options.src = argv._[0];
+  options.dest = argv.o || argv._[1];
+
+  if (!options.dest) {
+    var suffix = '.css';
+    if (/\.css$/.test(options.src)) {
+      suffix = '';
     }
+    options.dest = path.join(cwd, path.basename(options.src, '.scss') + suffix);
+  }
+
+  if (process.stdin.isTTY || process.env.isTTY) {
+    run(options, emitter);
+  } else {
+    stdin(function(data) {
+      options.data = data;
+      run(options, emitter);
+    });
   }
 
   return emitter;
 };
 
-exports.yargs = yargs;
+module.exports.yargs = yargs;

--- a/lib/render.js
+++ b/lib/render.js
@@ -3,59 +3,63 @@ var sass = require('../sass'),
     fs = require('fs');
 
 function render(options, emitter) {
-
-  sass.render({
-    file: options.inFile,
-    data: options.data,
-    includePaths: options.includePaths,
+  var renderOptions = {
     imagePath: options.imagePath,
-    outputStyle: options.outputStyle,
-    sourceComments: options.sourceComments,
-    sourceMap: options.sourceMap,
-    precision: options.precision,
-    outFile: options.outFile,
+    includePaths: options.includePaths,
     omitSourceMapUrl: options.omitSourceMapUrl,
-    success: function(css, sourceMap) {
+    outFile: options.outFile,
+    outputStyle: options.outputStyle,
+    precision: options.precision,
+    sourceComments: options.sourceComments,
+    sourceMap: options.sourceMap
+  };
 
-      var todo = 1;
-      var done = function() {
-        if (--todo <= 0) {
-          emitter.emit('done');
-        }
-      };
+  if (options.src) {
+    renderOptions.file = options.src;
+  } else if (options.data) {
+    renderOptions.data = options.data;
+  }
 
-      // Write to stdout
-      if (options.stdout) {
-        emitter.emit('log', css);
-        return done();
+  renderOptions.success = function(css, sourceMap) {
+    var todo = 1;
+    var done = function() {
+      if (--todo <= 0) {
+        emitter.emit('done');
       }
+    };
 
-      // Write to disk
-      emitter.emit('warn', chalk.green('Rendering Complete, saving .css file...'));
+    if (options.stdout || (!process.stdout.isTTY && !process.env.isTTY)) {
+      emitter.emit('log', css);
+      return done();
+    }
 
-      fs.writeFile(options.outFile, css, function(err) {
-        if (err) { return emitter.emit('error', chalk.red('Error: ' + err)); }
-        emitter.emit('warn', chalk.green('Wrote CSS to ' + options.outFile));
-        emitter.emit('write', err, options.outFile, css);
+    emitter.emit('warn', chalk.green('Rendering Complete, saving .css file...'));
+
+    fs.writeFile(options.dest, css, function(err) {
+      if (err) { return emitter.emit('error', chalk.red('Error: ' + err)); }
+      emitter.emit('warn', chalk.green('Wrote CSS to ' + options.dest));
+      emitter.emit('write', err, options.dest, css);
+      done();
+    });
+
+    if (options.sourceMap) {
+      todo++;
+      fs.writeFile(options.sourceMap, sourceMap, function(err) {
+        if (err) {return emitter.emit('error', chalk.red('Error' + err)); }
+        emitter.emit('warn', chalk.green('Wrote Source Map to ' + options.sourceMap));
+        emitter.emit('write-source-map', err, options.sourceMap, sourceMap);
         done();
       });
-
-      if (options.sourceMap) {
-        todo++;
-        fs.writeFile(options.sourceMap, sourceMap, function(err) {
-          if (err) {return emitter.emit('error', chalk.red('Error' + err)); }
-          emitter.emit('warn', chalk.green('Wrote Source Map to ' + options.sourceMap));
-          emitter.emit('write-source-map', err, options.sourceMap, sourceMap);
-          done();
-        });
-      }
-
-      emitter.emit('render', css);
-    },
-    error: function(error) {
-      emitter.emit('error', chalk.red(error));
     }
-  });
+
+    emitter.emit('render', css);
+  };
+
+  renderOptions.error = function(error) {
+    emitter.emit('error', chalk.red(error));
+  };
+
+  sass.render(renderOptions);
 }
 
 module.exports = render;

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "coveralls": "^2.11.1",
     "jscoverage": "^0.5.6",
     "jshint": "^2.5.5",
-    "mocha-lcov-reporter": "^0.0.1"
+    "mocha-lcov-reporter": "^0.0.1",
+    "object-assign": "^0.3.1"
   }
 }


### PR DESCRIPTION
A better solution for #410. The `process.env.isTTY` is used because when running tests it doesn't run them as a TTY and therefore they wont work correctly without settings this env flag.
