### PR TITLE
Fix path for sourceMap

### DIFF
--- a/sass.js
+++ b/sass.js
@@ -167,7 +167,7 @@ exports.renderFile = function(options) {
   options = assign({}, options);
   success = options.success;
   if (options.sourceMap === true) {
-    options.sourceMap = options.outFile + '.map';
+    options.sourceMap = path.basename(options.outFile) + '.map';
   }
   options.success = function(css, sourceMap) {
     fs.writeFile(options.outFile, css, function(err) {


### PR DESCRIPTION
fixes #425
- Use path.basename
