### PR TITLE
fix delete

### DIFF
--- a/sass_context_wrapper.cpp
+++ b/sass_context_wrapper.cpp
@@ -15,7 +15,6 @@ extern "C" {
   void free_file_context(sass_file_context* fctx) {
     delete[] fctx->input_path;
     delete[] fctx->options.include_paths;
-    delete[] fctx->options.image_path;
     sass_free_file_context(fctx);
   }
 


### PR DESCRIPTION
This line was causing a crash compiling one of my files:

```
site-css(77964,0x7fff71676310) malloc: *** error for object 0x1033231bd: pointer being freed was not allocated
```

The tests however passed before and are still passing.

This is on latest osx with latest developer tools, didn't happen before the recent update.
