### PR TITLE
Moved Appveyor setup to and added badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![logo](https://rawgit.com/sass/node-sass/master/media/logo.svg)
 
 [![Build Status](https://travis-ci.org/sass/node-sass.svg?branch=master&style=flat)](https://travis-ci.org/sass/node-sass)
+[![Build status](https://ci.appveyor.com/api/projects/status/22mjbk59kvd55m9y/branch/master)](https://ci.appveyor.com/project/sass/node-sass/branch/master)
 [![npm version](https://badge.fury.io/js/node-sass.svg)](http://badge.fury.io/js/node-sass)
 [![Dependency Status](https://david-dm.org/sass/node-sass.svg?theme=shields.io)](https://david-dm.org/sass/node-sass)
 [![devDependency Status](https://david-dm.org/sass/node-sass/dev-status.svg?theme=shields.io)](https://david-dm.org/sass/node-sass#info=devDependencies)


### PR DESCRIPTION
I moved the old Appveyor account from mine to @andrew's with a namechange to "sass".
@andrew let me know if this makes sense as I didn't realize I was renaming your Appveyor url slug when I did that :blush: 

The badge may also be bad till the first master build finishes
