### PR TITLE
Removed node-sass-middleware as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,22 +165,9 @@ Listing of community uses of node-sass in build tools and frameworks.
 
 ### Connect/Express middleware
 
-Recompile `.scss` files automatically for connect and express based http servers
+Recompile `.scss` files automatically for connect and express based http servers.
 
-```javascript
-var server = connect.createServer(
-  sass.middleware({
-      src: __dirname
-    , dest: __dirname + '/public'
-    , debug: true
-    , outputStyle: 'compressed'
-    , prefix:  '/prefix'
-  }),
-  connect.static('/prefix', __dirname + '/public')
-);
-```
-
-Heavily inspired by <https://github.com/LearnBoost/stylus>
+This functionality has been moved to [`node-sass-middleware`](https://github.com/sass/node-sass-middleware) in node-sass v1.0.0
 
 ### DocPad Plugin
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "object-assign": "~1.0.0",
     "shelljs": "~0.3.0",
     "sinon": "~1.10.3",
-    "node-sass-middleware": "~0.3.0",
     "yargs": "~1.3.1",
     "get-stdin": "~3.0.0"
   },

--- a/sass.js
+++ b/sass.js
@@ -199,4 +199,6 @@ exports.renderFile = function(options) {
   exports.render(options);
 };
 
-exports.middleware = require('node-sass-middleware');
+exports.middleware = function() {
+  return new Error('The middleware has been moved to https://github.com/sass/node-sass-middleware');
+};


### PR DESCRIPTION
We've already pulled all the functionality into https://github.com/sass/node-sass-middleware, but having it as a dependency in package.json makes for some weird circular dependencies.

Seeing as we're going 1.0.0, I don't have a problem breaking backwards compatibility a little.

I've left an error message to guide people in the right direction, we can drop that in a future version.
