### PR TITLE
Build: Uses different strategy to test bins status

### DIFF
--- a/build.js
+++ b/build.js
@@ -34,16 +34,21 @@ if (!force && !process.env.SKIP_NODE_SASS_TESTS) {
     fs.statSync(path.join(__dirname, 'bin', modPath, 'binding.node'));
     console.log('`'+ modPath+ '` exists; testing');
 
+    var total, failures;
     var mocha = new Mocha({
-      reporter: 'dot',
+      reporter: function (stats) {
+                  total = stats.total;
+                  failures = stats.failures;
+                },
       ui: 'bdd',
       timeout: 999999
     });
 
     mocha.addFile(path.resolve(__dirname, 'test', 'test.js'));
 
-    mocha.run(function (done) {
-      if (done !== 0) {
+    mocha.run(function () {
+      // at least 90% of tests should pass
+      if ((total - failures) * 100 / total < 90) {
         console.log('Problem with the binary; manual build incoming');
         console.log('Please consider contributing the release binary to https://github.com/sass/node-sass-binaries for npm distribution.');
         build();


### PR DESCRIPTION
Only 90% of the test should pass.

Related: https://github.com/sass/node-sass/issues/487#issuecomment-60902761 and https://github.com/sass/node-sass/issues/490.

/cc @andrew, @nschonni, @keithamus, @kevva
