### PR TITLE
Install: Bind to specific binaries commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sass",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "Wrapper around libsass",
   "license": "MIT",
   "homepage": "https://github.com/sass/node-sass",

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -37,8 +37,9 @@ function fetch(name) {
   });
 
   var url = [
-    'https://github.com/sass/node-sass-binaries/raw/master/',
-    name + '/binding.node'
+    'https://raw.githubusercontent.com/sass/node-sass/v',
+    require('../package.json').version, '/', name,
+    '/binding.node'
   ].join('');
 
   download.get(url);


### PR DESCRIPTION
Since we can't get file from tag via URL and it doesn't make sense to; release a node-sass-binaries, download a tarball and extract specific binary file, I think adding `node-sass-binaries` commit hash to package.json before releasing the npm is easy.

/cc @kevva 
