### PR TITLE
Set `options.src` to render the changed file when watching

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -156,6 +156,7 @@ function watch(options, emitter) {
   gaze.on('error', emitter.emit.bind(emitter, 'error'));
 
   gaze.on('changed', function(file) {
+    options = getOptions([file], options);
     emitter.emit('warn', '=> changed: ' + file);
     render(options, emitter);
   });


### PR DESCRIPTION
Also, should we reconsider the output option? Maybe changing it to be a directory instead of a file? Makes it easier if you're watching a directory instead of writing all files to `process.cwd()`.
