### PR TITLE
Apply correct cflags to source files

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -83,14 +83,8 @@
           ]
         }],
         ['OS!="win"', {
-          'cflags+': [
-            '-std=c++11'
-          ],
-          'cflags_c+': [
-            '-std=c++11'
-          ],
           'cflags_cc+': [
-            '-std=c++11'
+            '-std=c++0x'
           ]
         }]
       ]


### PR DESCRIPTION
Fixes the last warning in gyp build:

```
  CC(target) Release/obj.target/binding/src/libsass/cencode.o
cc1: warning: command line option '-std=c++11' is valid for C++/ObjC++ but not for C [enabled by default]
cc1: warning: command line option '-std=c++11' is valid for C++/ObjC++ but not for C [enabled by default]
```

Changes flag to `-std=c++0x` since it is enough to compile and is supported by much earlier gcc versions!
