### PR TITLE
Change `--output` to be a directory

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -3,6 +3,7 @@ var Emitter = require('events').EventEmitter,
     path = require('path'),
     Gaze = require('gaze'),
     meow = require('meow'),
+    replaceExt = require('replace-ext'),
     stdin = require('get-stdin'),
     render = require('../lib/render');
 
@@ -24,7 +25,7 @@ var cli = meow({
     'Options',
     '  -w, --watch                Watch a directory or file',
     '  -r, --recursive            Recursively watch directories or files',
-    '  -o, --output               Output CSS file',
+    '  -o, --output               Output directory',
     '  -x, --omit-source-map-url  Omit source map URL comment from output',
     '  -i, --indented-syntax      Treat data from stdin as sass code (versus scss)',
     '  --output-style             CSS output style (nested|expanded|compact|compressed)',
@@ -112,17 +113,21 @@ function getEmitter() {
  */
 
 function getOptions(args, options) {
+  var dir = options.output || process.cwd();
+
   options.src = args[0];
-  options.dest = options.output || args[1];
+  options.dest = args[1] ? path.join(dir, args[1]) : null;
 
   if (!options.dest && !options.stdout) {
+    var ext = path.extname(options.src);
+    var out = path.basename(options.src);
     var suffix = '.css';
 
-    if (/\.css$/.test(options.src)) {
-      suffix = '';
+    if (ext !== suffix) {
+      out = replaceExt(out, suffix);
     }
 
-    options.dest = path.join(process.cwd(), path.basename(options.src, '.scss') + suffix);
+    options.dest = path.join(dir, out);
   }
 
   return options;

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "mkdirp": "^0.5.0",
     "mocha": "^2.0.1",
     "nan": "^1.3.0",
-    "object-assign": "^1.0.0"
+    "object-assign": "^1.0.0",
+    "replace-ext": "0.0.1"
   },
   "devDependencies": {
     "coveralls": "^2.11.1",

--- a/test/cli.js
+++ b/test/cli.js
@@ -22,20 +22,6 @@ describe('cli', function() {
       src.pipe(bin.stdin);
     });
 
-    it('should write to disk when using --output', function(done) {
-      var src = fs.createReadStream(fixture('simple/index.scss'));
-      var dest = fixture('simple/build.css');
-      var bin = spawn(cli, ['--output', dest]);
-
-      bin.on('close', function() {
-        assert(fs.existsSync(dest));
-        fs.unlinkSync(dest);
-        done();
-      });
-
-      src.pipe(bin.stdin);
-    });
-
     it('should compile sass using the --indented-syntax option', function(done) {
       var src = fs.createReadStream(fixture('indent/index.sass'));
       var expected = read(fixture('indent/expected.css'), 'utf8').trim();
@@ -193,8 +179,8 @@ describe('cli', function() {
   describe('node-sass in.scss --output out.css', function() {
     it('should compile a scss file to build.css', function(done) {
       var src = fixture('simple/index.scss');
-      var dest = fixture('simple/build.css');
-      var bin = spawn(cli, [src, '--output', dest]);
+      var dest = fixture('simple/index.css');
+      var bin = spawn(cli, [src, '--output', path.dirname(dest)]);
 
       bin.on('close', function() {
         assert(fs.existsSync(dest));
@@ -205,10 +191,10 @@ describe('cli', function() {
 
     it('should compile with the --source-map option', function(done) {
       var src = fixture('source-map/index.scss');
-      var dest = fixture('source-map/build.css');
+      var dest = fixture('source-map/index.css');
       var expected = read(fixture('source-map/expected.css'), 'utf8').trim().replace(/\r\n/g, '\n');
       var map = fixture('source-map/index.map');
-      var bin = spawn(cli, [src, '--output', dest, '--source-map', map]);
+      var bin = spawn(cli, [src, '--output', path.dirname(dest), '--source-map', map]);
 
       bin.on('close', function () {
         assert.equal(read(dest, 'utf8').trim(), expected);
@@ -221,9 +207,12 @@ describe('cli', function() {
 
     it('should omit sourceMappingURL if --omit-source-map-url flag is used', function(done) {
       var src = fixture('source-map/index.scss');
-      var dest = fixture('source-map/build.css');
+      var dest = fixture('source-map/index.css');
       var map = fixture('source-map/index.map');
-      var bin = spawn(cli, [src, '--output', dest, '--source-map', map, '--omit-source-map-url']);
+      var bin = spawn(cli, [
+        src, '--output', path.dirname(dest),
+        '--source-map', map, '--omit-source-map-url'
+      ]);
 
       bin.on('close', function () {
         assert(read(dest, 'utf8').indexOf('sourceMappingURL') === -1);


### PR DESCRIPTION
This makes it easier to watch a lot of files for changes and compile them to a
desired directory rather than writing them in `process.cwd()`.

This would probably require a major bump since it's altering the CLI.
