### PR TITLE
Allow failures for node v0.11 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ compiler:
 node_js:
   - "0.10"
   - "0.11"
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: "0.11"
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test;
   - sudo apt-get update;


### PR DESCRIPTION
As v0.11 is supported at the moment, this makes it more helpful to know if v0.10 is passing tests.
