### PR TITLE
Manual build workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Check out the project:
     node-gyp rebuild
 
 ### Workaround for node `v0.11.13` `v0.11.14`
-Comment out this  [line](https://github.com/sass/node-sass/blob/e01497c4d4b8a7a7f4dbf9d607920ac10ad64445/lib/index.js#L181) in `lib/index.js` before the `npm install` step. Then uncomment it back again, and continue with the rest of the steps (#563).
+Follow the steps above, but comment out this [line](https://github.com/sass/node-sass/blob/e01497c4d4b8a7a7f4dbf9d607920ac10ad64445/lib/index.js#L181) in `lib/index.js` before the `npm install` step. Then uncomment it back again, and continue with the rest of the steps (see issue [#563](https://github.com/sass/node-sass/issues/563)).
 
 ## Command Line Interface
 


### PR DESCRIPTION
This describes a workaround for manually building on `v0.11.13/14`, in README.md. Originally mentioned in #563.
