### PR TITLE
 Importer: Drops uv_mutex in favor of std::mutex 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -206,6 +206,7 @@ module.exports.render = function(options) {
   if (importer) {
     options.importer = function(file, prev, key) {
       function done(data) {
+        console.log(data); // ugly hack
         binding.importedCallback({
           index: key,
           objectLiteral: data

--- a/src/sass_context_wrapper.cpp
+++ b/src/sass_context_wrapper.cpp
@@ -24,8 +24,9 @@ extern "C" {
 
   sass_context_wrapper* sass_make_context_wrapper() {
     sass_context_wrapper* ctx_w = (sass_context_wrapper*)calloc(1, sizeof(sass_context_wrapper));
-    uv_mutex_init(&ctx_w->importer_mutex);
-    uv_cond_init(&ctx_w->importer_condition_variable);
+
+    ctx_w->importer_mutex = new std::mutex();
+    ctx_w->importer_condition_variable = new std::condition_variable();
 
     return ctx_w;
   }
@@ -38,14 +39,14 @@ extern "C" {
       sass_delete_file_context(ctx_w->fctx);
     }
 
-    delete ctx_w->success_callback;
-    delete ctx_w->error_callback;
-    delete ctx_w->importer_callback;
     delete ctx_w->file;
     delete ctx_w->prev;
+    delete ctx_w->error_callback;
+    delete ctx_w->success_callback;
+    delete ctx_w->importer_callback;
 
-    uv_mutex_destroy(&ctx_w->importer_mutex);
-    uv_cond_destroy(&ctx_w->importer_condition_variable);
+    delete ctx_w->importer_mutex;
+    delete ctx_w->importer_condition_variable;
 
     NanDisposePersistent(ctx_w->result);
 

--- a/src/sass_context_wrapper.h
+++ b/src/sass_context_wrapper.h
@@ -1,4 +1,5 @@
 #include <nan.h>
+#include <condition_variable>
 #include "libsass/sass_context.h"
 
 #ifdef __cplusplus
@@ -12,20 +13,27 @@ extern "C" {
   void compile_it(uv_work_t* req);
 
   struct sass_context_wrapper {
+    // binding related
+    bool is_sync;
+    void* cookie;
+    const char* prev;
+    const char* file;
+    std::mutex* importer_mutex;
+    std::condition_variable* importer_condition_variable;
+
+    // libsass related
+    Sass_Import** imports;
     Sass_Data_Context* dctx;
     Sass_File_Context* fctx;
-    Persistent<Object> result;
-    uv_work_t request;
-    uv_mutex_t importer_mutex;
-    uv_cond_t importer_condition_variable;
+
+    // libuv related
     uv_async_t async;
-    const char* file;
-    const char* prev;
-    void* cookie;
-    bool is_sync;
-    Sass_Import** imports;
-    NanCallback* success_callback;
+    uv_work_t request;
+
+    // v8 and nan related
+    Persistent<Object> result;
     NanCallback* error_callback;
+    NanCallback* success_callback;
     NanCallback* importer_callback;
   };
 


### PR DESCRIPTION
* Importer: Drops `uv_mutex` in favor of `std::mutex`. (0720fa8)
    * It is not safe to use `uv_cond_wait`
      outside of v8 thread (`uv loop`).

* Importer: Hack to make CLI importer usage work. (ff53926)
  * If anyone could ever explain this!
  * This is related to the changes made in 0720fa8.
  * **Tidbit:** it was also failing on windows with node.js v0.10.32
     updating to v0.10.35 (current stable), it worked without this hack on Windows
     but when tested with v0.10.35 on Ubuntu via nvm, it still fails without this hack.
     The only downside of this hack is extra nuisance on console
     (I tried to dodge it by overriding `console.log` function, but that didn't work either, so we would have to live with this *little annoyance*<b>**</b>, until someone can figure out why it is happening).

@browniefed, @xzyfer, can you guys please confirm if this patch makes custom importer useable on Mac (and addresses https://github.com/sass/node-sass/issues/586)? 

---
\*\* without the hack running the following in cli hangs indefinitely:

```bash
node node_module/.bin/node-sass /path/to/input.scss --importer /path/to/importer.js
```

with the hack, it executes properly, but prints whatever custom importer returns. Tested on Ubuntu and Windows.

**Note 1:** If the importer option is not set (in CLI or `render()` usage, leaving `renderSync()` alone), no unwanted / extra stuff will not be printed. 
**Note 2:** This means we would have to apply same hack to `custom functions` feature (#332), whenever we will implement it. :)
**Note 3:** We use `render` (as opposed to `renderSync`) in case of CLI usage, because we [route the errors to emitter](https://github.com/sass/node-sass/blob/ff539261cb2848b65cfc45843ac8cc97aca59eb7/lib/render.js#L86). In case of `renderSync`, the errors are *thrown* to stderr. <sup>[[1]](https://github.com/sass/node-sass/blob/ff539261cb2848b65cfc45843ac8cc97aca59eb7/src/binding.cpp#L295) &nbsp; [[2]](https://github.com/sass/node-sass/blob/ff539261cb2848b65cfc45843ac8cc97aca59eb7/src/binding.cpp#L340)</sup>