### PR TITLE
Use sass-graph for accurate sass watching

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -5,6 +5,7 @@ var Emitter = require('events').EventEmitter,
     meow = require('meow'),
     replaceExt = require('replace-ext'),
     stdin = require('get-stdin'),
+    grapher = require('sass-graph'),
     render = require('../lib/render');
 
 /**
@@ -183,10 +184,20 @@ function watch(options, emitter) {
   gaze.add(dir);
   gaze.on('error', emitter.emit.bind(emitter, 'error'));
 
+  var graph = grapher.parseDir(options.src, { loadPaths: options.includePath });
+
   gaze.on('changed', function(file) {
-    options = getOptions([file], options);
-    emitter.emit('warn', '=> changed: ' + file);
-    render(options, emitter);
+    var files = [file];
+    graph.visitAncestors(file, function(parent) {
+      files.push(parent);
+    });
+
+    files.forEach(function(file) {
+      if (path.basename(file)[0] === '_') return;
+      options = getOptions([path.resolve(file)], options);
+      emitter.emit('warn', '=> changed: ' + file);
+      render(options, emitter);
+    });
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "object-assign": "^2.0.0",
     "replace-ext": "0.0.1",
     "request": "^2.48.0",
+    "sass-graph": "^1.0.1",
     "shelljs": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem 

The watcher is broken. So very broken. Two major problems with it

- it compiles files starting with underscores (`_`) which is a big no-no
- it has no awareness of the the import graph

Assuming the following directory structure

```
src
|--foo.scss
|--bar.scss
|-- components
   |-- _baz.scss
```

where 'foo.scss` and `bar.scss`, and running the following command `node-sass -w -r --output dist src`.

A modification to `src/components/_baz.scss` **should not** compile `_baz.scss`. It **should** traverse the import graph and compile `dist/foo.css` and `dist/bar.css`.

This is how the native sass watcher works.

## Solution

Use [sass-graph](https://github.com/xzyfer/sass-graph) to build an in memory graph of the `@imports` to determine the correct compilation targets for a modified file.

I believe this is the issue at the heart of https://github.com/sass/node-sass/issues/157.