### PR TITLE
iojs support

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "meow": "^2.0.0",
     "mkdirp": "^0.5.0",
     "mocha": "^2.0.1",
-    "nan": "^1.3.0",
+    "nan": "^1.5.1",
     "npmconf": "^2.1.1",
     "object-assign": "^2.0.0",
     "replace-ext": "0.0.1",

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -30,8 +30,8 @@ void prepare_import_results(Local<Value> returned_value, sass_context_wrapper* c
         continue;
 
       Local<Object> object = Local<Object>::Cast(value);
-      char* path = CreateString(object->Get(String::New("file")));
-      char* contents = CreateString(object->Get(String::New("contents")));
+      char* path = CreateString(object->Get(NanNew<String>("file")));
+      char* contents = CreateString(object->Get(NanNew<String>("contents")));
 
       ctx_w->imports[i] = sass_make_import_entry(path, (!contents || contents[0] == '\0') ? 0 : strdup(contents), 0);
     }
@@ -39,8 +39,8 @@ void prepare_import_results(Local<Value> returned_value, sass_context_wrapper* c
   else if (returned_value->IsObject()) {
     ctx_w->imports = sass_make_import_list(1);
     Local<Object> object = Local<Object>::Cast(returned_value);
-    char* path = CreateString(object->Get(String::New("file")));
-    char* contents = CreateString(object->Get(String::New("contents")));
+    char* path = CreateString(object->Get(NanNew<String>("file")));
+    char* contents = CreateString(object->Get(NanNew<String>("contents")));
 
     ctx_w->imports[0] = sass_make_import_entry(path, (!contents || contents[0] == '\0') ? 0 : strdup(contents), 0);
   }


### PR DESCRIPTION
This allows node-sass to build on iojs. Tests suite passes with iojs 1.0.1 and node.js 0.10.31.  Are there other node versions that should be tested as well?

Addresses https://github.com/sass/node-sass/issues/627.

One thing to note when manually rebuilding is that upstream node-gyp doesn't yet support iojs, so you need to make sure you're building using node-gyp bundled with iojs: https://github.com/iojs/io.js/issues/433