### PR TITLE
Don't exit if an error occurs while watching

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -98,7 +98,9 @@ function getEmitter() {
 
   emitter.on('error', function(err) {
     console.error(err);
-    process.exit(1);
+    if (!options.watch) {
+      process.exit(1);
+    }
   });
 
   emitter.on('warn', function(data){


### PR DESCRIPTION
If the user specified to watch a directory/file and an error occurs we shouldn't stop the process.