### PR TITLE
Build: Produces identifiable binary name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 var fs = require('fs'),
-    path = require('path');
+    path = require('path'),
+    utils = require('./utils');
 
 /**
  * Get binding
@@ -8,11 +9,10 @@ var fs = require('fs'),
  */
 
 function getBinding() {
-  var name = process.platform + '-' + process.arch;
   var candidates = [
     path.join(__dirname, '..', 'build', 'Release', 'binding.node'),
     path.join(__dirname, '..', 'build', 'Debug', 'binding.node'),
-    path.join(__dirname, '..', 'vendor', name, 'binding.node')
+    path.join(__dirname, '..', 'vendor', utils.getBinaryIdentifiableName(), 'binding.node')
   ];
 
   var candidate = candidates.filter(fs.existsSync)[0];
@@ -255,6 +255,7 @@ module.exports.renderSync = function(options) {
 /**
  * API Info
  *
+ * @api public
  */
 
 module.exports.info = function() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,8 +10,8 @@ var fs = require('fs'),
 
 function getBinding() {
   var candidates = [
-    path.join(__dirname, '..', 'build', 'Release', 'binding.node'),
     path.join(__dirname, '..', 'build', 'Debug', 'binding.node'),
+    path.join(__dirname, '..', 'build', 'Release', 'binding.node'),
     path.join(__dirname, '..', 'vendor', utils.getBinaryIdentifiableName(), 'binding.node')
   ];
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,28 @@
+var semver = require('semver'),
+    runtimeVersion = semver.parse(process.version);
+
+/**
+ * Get Runtime Name
+ *
+ * @api private
+ */
+
+function getRuntimeName() {
+  return process.execPath
+        .split(/[\\/]+/).pop()
+        .split('.')[0];
+}
+
+/**
+ * Get unique name of binary for current platform
+ *
+ * @api public
+ */
+
+module.exports.getBinaryIdentifiableName = function() {
+  return process.platform + '-' +
+         process.arch + '-' +
+         getRuntimeName() + '-' +
+         runtimeVersion.major + '.' +
+         runtimeVersion.minor;
+};

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "chalk": "^0.5.1",
-    "cross-spawn": "^0.2.3",
+    "cross-spawn": "^0.2.6",
     "gaze": "^0.5.1",
     "get-stdin": "^4.0.1",
     "meow": "^3.0.0",
@@ -56,6 +56,7 @@
     "replace-ext": "0.0.1",
     "request": "^2.53.0",
     "sass-graph": "^1.0.3",
+    "semver": "^4.2.2",
     "shelljs": "^0.3.0"
   },
   "devDependencies": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -2,7 +2,8 @@ var fs = require('fs'),
     path = require('path'),
     spawn = require('child_process').spawn,
     mkdir = require('mkdirp'),
-    Mocha = require('mocha');
+    Mocha = require('mocha'),
+    utils = require('../lib/utils');
 
 /**
  * After build
@@ -109,7 +110,7 @@ function parseArgs(args) {
  */
 
 function testBinary(options) {
-  options.bin = options.platform + '-' + options.arch;
+  options.bin = utils.getBinaryIdentifiableName();
 
   if (options.force || process.env.SASS_FORCE_BUILD) {
     return build(options);

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -2,7 +2,8 @@ var fs = require('fs'),
     path = require('path'),
     request = require('request'),
     mkdirp = require('mkdirp'),
-    exec = require('shelljs').exec;
+    exec = require('shelljs').exec,
+    utils = require('../lib/utils');
 
 /**
  * Download file, if succeeds save, if not delete
@@ -76,7 +77,7 @@ function applyProxy(options, cb) {
  */
 
 function exists() {
-  var name = process.platform + '-' + process.arch;
+  var name = utils.getBinaryIdentifiableName();
 
   fs.exists(path.join(__dirname, '..', 'vendor', name), function (exists) {
     if (exists) {


### PR DESCRIPTION
The new format is:
`{platform}-{arch}-{runtime}-{major.minor}`
where `major` and `minor` version belong to
the runtime.

Related Issue: #655.

//cc @xzyfer 