### PR TITLE
Include correct header for malloc related functions.

### DIFF
--- a/src/sass_context_wrapper.h
+++ b/src/sass_context_wrapper.h
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <nan.h>
 #include <condition_variable>
 #include "libsass/sass_context.h"


### PR DESCRIPTION
The C malloc() functions require inclusion of ``stdlib.h``

This fixes compilation on FreeBSD.