### PR TITLE
Improve install script

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -16,27 +16,17 @@ require('../lib/extensions');
  */
 
 function download(url, dest, cb) {
-  var file = fs.createWriteStream(dest);
-
   applyProxy({ rejectUnauthorized: false }, function(options) {
     var returnError = function(err) {
-      fs.unlink(dest);
       cb(typeof err.message === 'string' ? err.message : err);
     };
-    var req = request.get(url, options).on('response', function(response) {
+    request.get(url, options).on('response', function(response) {
       if (response.statusCode < 200 || response.statusCode >= 300) {
         returnError('Can not download file from ' + url);
         return;
       }
-      response.pipe(file);
-
-      file.on('finish', function() {
-        file.close(cb);
-      });
+      response.pipe(fs.createWriteStream(dest));
     }).on('error', returnError);
-
-    req.end();
-    req.on('error', returnError);
   });
 }
 


### PR DESCRIPTION
The main goal of this PR is to solve an error. When there are some kind of errors downloading the binary file (network errors mostly) the file where it was going to be downloaded to is not unlinked and left as an empty file and then the build script "thinks" that the download went ok and does not do the manual build. I changed the code to create the file just when it is necessary.