### PR TITLE
Fix failing build; fixes #665

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -88,8 +88,8 @@ function checkAndFetchBinaries() {
 
 function fetch() {
   var url = [
-    'https://raw.githubusercontent.com/sass/node-sass-binaries/v',
-    packageInfo.version, '/', process.sassBinaryName,
+    'https://raw.githubusercontent.com/sass/node-sass-binaries/master',
+    '/', process.sassBinaryName,
     '/binding.node'
   ].join('');
   var dir = path.join(__dirname, '..', 'vendor', process.sassBinaryName);


### PR DESCRIPTION
Current build fails because node-sass-binaries is not available from version branches (seems deleted?). Fixing this by setting branch name as master.