### PR TITLE
Misc. Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,9 +279,6 @@ npm install -g node-gyp
 node-gyp rebuild  # to make debug release, use -d switch
 ```
 
-### Workaround for node `v0.11.13` `v0.11.14`
-Follow the steps above, but comment out this [line](https://github.com/sass/node-sass/blob/e01497c4d4b8a7a7f4dbf9d607920ac10ad64445/lib/index.js#L181) in `lib/index.js` before the `npm install` step. Then uncomment it back again, and continue with the rest of the steps (see issue [#563](https://github.com/sass/node-sass/issues/563)).
-
 ## Command Line Interface
 
 The interface for command-line usage is fairly simplistic at this stage, as seen in the following usage section.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The API for using node-sass has changed, so that now there is only one variable 
 `data` is a `String` containing the scss to be rendered by [libsass]. One of this or `file` options are required, for both render and renderSync. It is recommended that you use the `includePaths` option in conjunction with this, as otherwise [libsass] may have trouble finding files imported via the `@import` directive.
 
 #### success
-`success` is a `Function` to be called upon successful rendering of the scss to css. This option is required but only for the render function. If provided to renderSync it will be ignored.
+`success` is a `Function` to be called upon successful rendering of the scss to css. This option is required but only for the render function. If provided to `renderSync` it will be ignored. The error object take
 
 The callback function is passed a results object, containing the following keys:
 
@@ -89,7 +89,17 @@ The callback function is passed a results object, containing the following keys:
     * `includedFiles` - Absolute paths to all related scss files in no particular order.
 
 #### error
-`error` is a `Function` to be called upon occurrence of an error when rendering the scss to css. This option is optional, and only applies to the render function. If provided to renderSync it will be ignored.
+`error` is a `Function` to be called upon occurrence of an error when rendering the scss to css. This option is optional, and only applies to the render function.
+
+The callback function is passed an error object, containing the following keys:
+
+* `message` - The error message.
+* `line` - The line number of error.
+* `column` - The column number of error.
+* `status` - The status code.
+* `file` - The filename of error. In case `file` option was not set (in favour of `data`), this will reflect the value `stdin`.
+
+Note: If this option is provided to renderSync it will be ignored. In case of `renderSync` the error is thrown to stderr, which is try-catchable. In catch block, the same error object will be received.
 
 #### importer (starting from v2)
 `importer` is a `Function` to be called when libsass parser encounters the import directive. If present, libsass will call node-sass and let the user change file, data or both during the compilation. This option is optional, and applies to both render and renderSync functions. Also, it can either return object of form `{file:'..', contents: '..'}` or send it back via `done({})`. Note in renderSync or render, there is no restriction imposed on using `done()` callback or `return` statement (dispite of the asnchrony difference).
@@ -141,10 +151,10 @@ sass.render({
         console.log(result.stats);
         console.log(result.map)
 	},
-	error: function(error) {
+	error: function(error) { // starting v2.1 error is an Error-typed object
 		// error is an object: v2 change
 		console.log(error.message);
-		console.log(error.code);
+		console.log(error.status); // changed from code to status in v2.1
 		console.log(error.line);
 		console.log(error.column); // new in v2
 	},

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
     - nodejs_version: 0.10
     - nodejs_version: 0.12
     # io.js
-    - nodejs_version: "1.1"
+    - nodejs_version: "1.2"
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -1,18 +1,26 @@
 var semver = require('semver'),
-    runtimeVersion = semver.parse(process.version);
+    runtimeVersion = semver.parse(process.version),
+    fs = require('fs');
 
 /**
- * Get Runtime Name
+ * Get Runtime Info
  *
  * @api private
  */
 
-function getRuntimeName() {
-  var runtime = process.execPath
+function getRuntimeInfo() {
+  var execPath = fs.realpathSync(process.execPath); // resolve symbolic link
+
+  var runtime = execPath
                .split(/[\\/]+/).pop()
                .split('.').shift();
 
-  return runtime === 'nodejs' ? 'node' : runtime;
+  runtime = runtime === 'nodejs' ? 'node' : runtime;
+
+  return {
+    name: runtime,
+    execPath: execPath
+  };
 }
 
 /**
@@ -24,10 +32,10 @@ function getRuntimeName() {
 function getBinaryIdentifiableName() {
   return [process.platform, '-',
           process.arch, '-',
-          getRuntimeName(), '-',
+          process.runtime.name, '-',
           runtimeVersion.major, '.',
           runtimeVersion.minor].join('');
 }
 
-process.runtime = getRuntimeName();
+process.runtime = getRuntimeInfo();
 process.sassBinaryName = getBinaryIdentifiableName();

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 var fs = require('fs'),
-    path = require('path');
+    path = require('path'),
+    util = require('util');
 
 require('./extensions');
 
@@ -146,12 +147,9 @@ function getOptions(options) {
   var error = options.error;
   var success = options.success;
 
-  options.error = function(err, code) {
-    err = JSON.parse(err);
-    err.code = code;
-
+  options.error = function(err) {
     if (error) {
-      error(err);
+      error(util._extend(new Error(), JSON.parse(err)));
     }
   };
 
@@ -246,6 +244,8 @@ module.exports.renderSync = function(options) {
 
     return result;
   }
+
+  throw util._extend(new Error(), JSON.parse(result.error));
 };
 
 /**

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -50,7 +50,11 @@ function afterBuild(options) {
  */
 
 function build(options) {
-  var proc = spawn(process.execPath, ['node_modules/pangyp/bin/node-gyp', 'rebuild'].concat(options.args), {
+  var arguments = ['node_modules/pangyp/bin/node-gyp', 'rebuild'].concat(options.args);
+
+  console.log(['Building:', process.runtime.execPath].concat(arguments).join(' '));
+
+  var proc = spawn(process.runtime.execPath, arguments, {
     stdio: [0, 1, 2]
   });
 


### PR DESCRIPTION
* README: Removes v0.11 workaround section
  * Reason: njs v0.11 is not relavent any more.
  * Solution: Update to node v0.12 with which<br />
                  node-sass v2.0.1 is compatible OOTB.

* CI: Updates io.js to 1.2 for AppVeyor.

* Code: Throws `Error` object.
  * Returns json-string error from LibSass as is.
  * Extends empty error object with parsed JSON.<br/>
  Note: The reason why [`NanError`](https://github.com/rvagg/nan#nanerrormessage-nantypeerrormessage-nanrangeerrormessage) is not used<br />because LibSass returns error as JSON<br /> string with `message` as member, so we would<br/> have to reparse and reassign the obj in that case.<br/>Issue URL: #675.

* README: Updates error info. (related to previous commit)

* Code: Uses more C++ style nomenclature. 

* Code: Resolves symbolic link.  <br/>On Windows, process.execPath does not
get resolved symlink path. This commit
fixes the issue.<br/>Related Issue: iojs/io.js#851.
