### PR TITLE
Render options in callbacks as this.options

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The API for using node-sass has changed, so that now there are only two variable
 `data` is a `String` containing the scss to be rendered by [libsass]. One of this or `file` options are required, for both render and renderSync. It is recommended that you use the `includePaths` option in conjunction with this, as otherwise [libsass] may have trouble finding files imported via the `@import` directive.
 
 #### deprecated: success / error
-> `success` is a `Function` to be called upon successful rendering of the scss to css. This option is required but only for the render function. If provided to `renderSync` it will be ignored. The error object take
+> `success` is a `Function` to be called upon successful rendering of the scss to css. This option is required but only for the render function. If provided to `renderSync` it will be ignored.
 >
 > The callback function is passed a results object, containing the following keys:
 >
@@ -102,6 +102,8 @@ The API for using node-sass has changed, so that now there are only two variable
 
 #### importer (starting from v2)
 `importer` is a `Function` to be called when libsass parser encounters the import directive. If present, libsass will call node-sass and let the user change file, data or both during the compilation. This option is optional, and applies to both render and renderSync functions. Also, it can either return object of form `{file:'..', contents: '..'}` or send it back via `done({})`. Note in renderSync or render, there is no restriction imposed on using `done()` callback or `return` statement (dispite of the asnchrony difference).
+
+The options passed in to `render` and `renderSync` are available as `this.options` within the `Function`.
 
 #### includePaths
 `includePaths` is an `Array` of path `String`s to look for any `@import`ed files. It is recommended that you use this option if you are using the `data` option and have **any** `@import` directives, as otherwise [libsass] may not find your depended-on files.
@@ -139,6 +141,8 @@ You must define this option as well as `outFile` in order to generate a source m
 
 ### The `render` Callback
 node-sass supports standard node style callbacks with the signature of `function(err, result)`. In error conditions, the `err` argument is populated with the error object. In success conditions, the `result` object is populated with an object describing the result of the render call.
+
+By default, the callback runs with the `this` context set to an object describing the Sass environment. The options passed in to `render` and `renderSync` are available as `this.options`.
 
 #### The Error Object
 * `message` - The error message.

--- a/README.md
+++ b/README.md
@@ -54,9 +54,8 @@ Compiling versions 0.9.4 and above on Windows machines requires [Visual Studio 2
 var sass = require('node-sass');
 sass.render({
 	file: scss_filename,
-	success: callback
 	[, options..]
-	});
+}, function(err, result) { /*...*/ });
 // OR
 var result = sass.renderSync({
 	data: scss_content
@@ -66,7 +65,7 @@ var result = sass.renderSync({
 
 ### Options
 
-The API for using node-sass has changed, so that now there is only one variable - an options hash. Some of these options are optional, and in some circumstances some are mandatory.
+The API for using node-sass has changed, so that now there are only two variables - an options hash and a callback. Some of these options are optional, and in some circumstances some are mandatory.
 
 #### file
 `file` is a `String` of the path to an `scss` file for [libsass] to render. One of this or `data` options are required, for both render and renderSync.
@@ -74,32 +73,32 @@ The API for using node-sass has changed, so that now there is only one variable 
 #### data
 `data` is a `String` containing the scss to be rendered by [libsass]. One of this or `file` options are required, for both render and renderSync. It is recommended that you use the `includePaths` option in conjunction with this, as otherwise [libsass] may have trouble finding files imported via the `@import` directive.
 
-#### success
-`success` is a `Function` to be called upon successful rendering of the scss to css. This option is required but only for the render function. If provided to `renderSync` it will be ignored. The error object take
-
-The callback function is passed a results object, containing the following keys:
-
-* `css` - The compiled CSS. Write this to a file, or serve it out as needed.
-* `map` - The source map
-* `stats` - An object containing information about the compile. It contains the following keys:
-    * `entry` - The path to the scss file, or `data` if the source was not a file
-    * `start` - Date.now() before the compilation
-    * `end` - Date.now() after the compilation
-    * `duration` - *end* - *start*
-    * `includedFiles` - Absolute paths to all related scss files in no particular order.
-
-#### error
-`error` is a `Function` to be called upon occurrence of an error when rendering the scss to css. This option is optional, and only applies to the render function.
-
-The callback function is passed an error object, containing the following keys:
-
-* `message` - The error message.
-* `line` - The line number of error.
-* `column` - The column number of error.
-* `status` - The status code.
-* `file` - The filename of error. In case `file` option was not set (in favour of `data`), this will reflect the value `stdin`.
-
-Note: If this option is provided to renderSync it will be ignored. In case of `renderSync` the error is thrown to stderr, which is try-catchable. In catch block, the same error object will be received.
+#### deprecated: success / error
+> `success` is a `Function` to be called upon successful rendering of the scss to css. This option is required but only for the render function. If provided to `renderSync` it will be ignored. The error object take
+>
+> The callback function is passed a results object, containing the following keys:
+>
+> * `css` - The compiled CSS. Write this to a file, or serve it out as needed.
+> * `map` - The source map
+> * `stats` - An object containing information about the compile. It contains the following keys:
+>   * `entry` - The path to the scss file, or `data` if the source was not a file
+>   * `start` - Date.now() before the compilation
+>   * `end` - Date.now() after the compilation
+>   * `duration` - *end* - *start*
+>   * `includedFiles` - Absolute paths to all related scss files in no particular order.
+>
+>
+> `error` is a `Function` to be called upon occurrence of an error when rendering the scss to css. This option is optional, and only applies to the render function.
+>
+> The callback function is passed an error object, containing the following keys:
+>
+> * `message` - The error message.
+> * `line` - The line number of error.
+> * `column` - The column number of error.
+> * `status` - The status code.
+> * `file` - The filename of error. In case `file` option was not set (in favour of `data`), this will reflect the value `stdin`.
+>
+> Note: If this option is provided to renderSync it will be ignored. In case of `renderSync` the error is thrown to stderr, which is try-catchable. In catch block, the same error object will be received.
 
 #### importer (starting from v2)
 `importer` is a `Function` to be called when libsass parser encounters the import directive. If present, libsass will call node-sass and let the user change file, data or both during the compilation. This option is optional, and applies to both render and renderSync functions. Also, it can either return object of form `{file:'..', contents: '..'}` or send it back via `done({})`. Note in renderSync or render, there is no restriction imposed on using `done()` callback or `return` statement (dispite of the asnchrony difference).
@@ -138,6 +137,26 @@ You must define this option as well as `outFile` in order to generate a source m
 #### sourceMapContents
 `sourceMapContents` is a `Boolean` flag to determine whether to include `contents` in maps.
 
+### The `render` Callback
+node-sass supports standard node style callbacks with the signature of `function(err, result)`. In error conditions, the `err` argument is populated with the error object. In success conditions, the `result` object is populated with an object describing the result of the render call.
+
+#### The Error Object
+* `message` - The error message.
+* `line` - The line number of error.
+* `column` - The column number of error.
+* `status` - The status code.
+* `file` - The filename of error. In case `file` option was not set (in favour of `data`), this will reflect the value `stdin`.
+
+#### The Result Object
+* `css` - The compiled CSS. Write this to a file, or serve it out as needed.
+* `map` - The source map
+* `stats` - An object containing information about the compile. It contains the following keys:
+  * `entry` - The path to the scss file, or `data` if the source was not a file
+  * `start` - Date.now() before the compilation
+  * `end` - Date.now() after the compilation
+  * `duration` - *end* - *start*
+  * `includedFiles` - Absolute paths to all related scss files in no particular order.
+
 ### Examples
 
 ```javascript
@@ -145,19 +164,6 @@ var sass = require('node-sass');
 sass.render({
 	file: '/path/to/myFile.scss',
 	data: 'body{background:blue; a{color:black;}}',
-	success: function(result) {
-		// result is an object: v2 change
-        console.log(result.css);
-        console.log(result.stats);
-        console.log(result.map)
-	},
-	error: function(error) { // starting v2.1 error is an Error-typed object
-		// error is an object: v2 change
-		console.log(error.message);
-		console.log(error.status); // changed from code to status in v2.1
-		console.log(error.line);
-		console.log(error.column); // new in v2
-	},
 	importer: function(url, prev, done) {
 		// url is the path in import as is, which libsass encountered.
 		// prev is the previously resolved path.
@@ -174,6 +180,21 @@ sass.render({
 	},
 	includePaths: [ 'lib/', 'mod/' ],
 	outputStyle: 'compressed'
+}, function(error, result) {
+  if (error) {
+    // starting v2.1 error is an Error-typed object
+    // error is an object: v2 change
+    console.log(error.message);
+    console.log(error.status); // changed from code to status in v2.1
+    console.log(error.line);
+    console.log(error.column); // new in v2
+  }
+  else if (result) {
+    // result is an object: v2 change
+    console.log(result.css);
+    console.log(result.stats);
+    console.log(result.map)
+  }
 });
 // OR
 var result = sass.renderSync({

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 var fs = require('fs'),
     path = require('path'),
-    util = require('util');
+    util = require('util'),
+    clone = require('clone');
 
 require('./extensions');
 
@@ -127,9 +128,8 @@ function getSourceMap(options) {
  * @param {Object} options
  * @api private
  */
-
 function getOptions(options, nodeCallback) {
-  options = options || {};
+  options = options ? clone(options) : {};
   options.comments = options.source_comments || options.sourceComments || false;
   options.data = options.data || null;
   options.file = options.file || null;
@@ -139,6 +139,8 @@ function getOptions(options, nodeCallback) {
   options.precision = parseInt(options.precision) || 5;
   options.sourceMap = getSourceMap(options);
   options.style = getStyle(options) || 0;
+  options.state = {};
+  options.context = { options: options };
 
   if (options.imagePath && typeof options.imagePath !== 'string') {
     throw new Error('`imagePath` needs to be a string');
@@ -150,10 +152,10 @@ function getOptions(options, nodeCallback) {
   options.error = function(err) {
     var payload = util._extend(new Error(), JSON.parse(err));
     if (nodeCallback) {
-      nodeCallback(payload, null);
+      nodeCallback.call(options.context, payload, null);
     }
     if (error) {
-      error(payload);
+      error.call(options.context, payload);
     }
   };
 
@@ -167,10 +169,14 @@ function getOptions(options, nodeCallback) {
     };
 
     if (nodeCallback) {
-      nodeCallback(null, payload);
+      nodeCallback.call(options.context, null, payload);
     }
     if (success) {
-      success(payload);
+      success.call(options.context, {
+        css: result.css,
+        map: result.map,
+        stats: stats
+      });
     }
   };
 
@@ -215,7 +221,7 @@ module.exports.render = function(options, cb) {
         });
       }
 
-      var result = importer(file, prev, done);
+      var result = importer.call(options.context, file, prev, done);
 
       if (result) {
         done(result);
@@ -240,7 +246,7 @@ module.exports.renderSync = function(options) {
 
   if (importer) {
     options.importer = function(file, prev) {
-      return { objectLiteral: importer(file, prev) };
+      return { objectLiteral: importer.call(options.context, file, prev) };
     };
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -139,8 +139,14 @@ function getOptions(options, nodeCallback) {
   options.precision = parseInt(options.precision) || 5;
   options.sourceMap = getSourceMap(options);
   options.style = getStyle(options) || 0;
-  options.state = {};
-  options.context = { options: options };
+
+  // context object represents node-sass environment
+  options.context = {
+    info: module.exports.info,
+    state: {},
+    sync: false,
+    options: options
+  };
 
   if (options.imagePath && typeof options.imagePath !== 'string') {
     throw new Error('`imagePath` needs to be a string');
@@ -241,7 +247,7 @@ module.exports.render = function(options, cb) {
 
 module.exports.renderSync = function(options) {
   options = getOptions(options);
-
+  options.context.sync = true;
   var importer = options.importer;
 
   if (importer) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -128,7 +128,7 @@ function getSourceMap(options) {
  * @api private
  */
 
-function getOptions(options) {
+function getOptions(options, nodeCallback) {
   options = options || {};
   options.comments = options.source_comments || options.sourceComments || false;
   options.data = options.data || null;
@@ -148,21 +148,29 @@ function getOptions(options) {
   var success = options.success;
 
   options.error = function(err) {
+    var payload = util._extend(new Error(), JSON.parse(err));
+    if (nodeCallback) {
+      nodeCallback(payload, null);
+    }
     if (error) {
-      error(util._extend(new Error(), JSON.parse(err)));
+      error(payload);
     }
   };
 
   options.success = function() {
     var result = options.result;
     var stats = endStats(result.stats);
+    var payload = {
+      css: result.css,
+      map: result.map,
+      stats: stats
+    };
 
+    if (nodeCallback) {
+      nodeCallback(null, payload);
+    }
     if (success) {
-      success({
-        css: result.css,
-        map: result.map,
-        stats: stats
-      });
+      success(payload);
     }
   };
 
@@ -192,8 +200,8 @@ var binding = require(getBinding());
  * @api public
  */
 
-module.exports.render = function(options) {
-  options = getOptions(options);
+module.exports.render = function(options, cb) {
+  options = getOptions(options, cb);
 
   var importer = options.importer;
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   ],
   "dependencies": {
     "chalk": "^0.5.1",
+    "clone": "^1.0.0",
     "cross-spawn": "^0.2.6",
     "gaze": "^0.5.1",
     "get-stdin": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sass",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "libsass": "3.1.0",
   "description": "Wrapper around libsass",
   "license": "MIT",

--- a/test/api.js
+++ b/test/api.js
@@ -321,7 +321,7 @@ describe('api', function() {
         }
       });
     });
-	
+
     it('should override imports with "data" as input and fires callback with contents', function(done) {
       sass.render({
         data: src,
@@ -393,6 +393,23 @@ describe('api', function() {
         importer: function() {
           assert.equal(fxt, this.options.file);
           return {};
+        }
+      });
+    });
+
+    it('should be able to view a persistent state object', function(done) {
+      sass.render({
+        data: src,
+        success: function() {
+          assert.equal(this.state.count, 2);
+          done();
+        },
+        importer: function() {
+          this.state.count = this.state.count || 0;
+          this.state.count++;
+          return {
+            contents: 'div {color: yellow;}'
+          };
         }
       });
     });
@@ -530,7 +547,7 @@ describe('api', function() {
       assert.equal(result.css.trim(), '');
       done();
     });
-	
+
     it('should override imports with "data" as input and returns contents', function(done) {
       var result = sass.renderSync({
         data: src,
@@ -765,8 +782,8 @@ describe('api', function() {
   describe('.info()', function() {
     it('should return a correct version info', function(done) {
       assert.equal(sass.info(), [
-        'node-sass version: ' + require('../package.json').version, 
-        'libsass version: ' + require('../package.json').libsass 
+        'node-sass version: ' + require('../package.json').version,
+        'libsass version: ' + require('../package.json').libsass
       ].join('\n'));
 
       done();

--- a/test/api.js
+++ b/test/api.js
@@ -381,6 +381,21 @@ describe('api', function() {
         }
       });
     });
+
+    it('should be able to see its options in this.options', function(done) {
+      var fxt = fixture('include-files/index.scss');
+      sass.render({
+        file: fxt,
+        success: function() {
+          assert.equal(fxt, this.options.file);
+          done();
+        },
+        importer: function() {
+          assert.equal(fxt, this.options.file);
+          return {};
+        }
+      });
+    });
   });
 
   describe('.renderSync(options)', function() {
@@ -541,6 +556,21 @@ describe('api', function() {
       });
 
       assert.equal(result.css.trim(), 'div {\n  color: yellow; }\n\ndiv {\n  color: yellow; }');
+      done();
+    });
+
+    it('should be able to see its options in this.options', function(done) {
+      var fxt = fixture('include-files/index.scss');
+      var sync = false;
+      sass.renderSync({
+        file: fixture('include-files/index.scss'),
+        importer: function() {
+          assert.equal(fxt, this.options.file);
+          sync = true;
+          return {};
+        }
+      });
+      assert.equal(sync, true);
       done();
     });
   });

--- a/test/api.js
+++ b/test/api.js
@@ -173,6 +173,28 @@ describe('api', function() {
     });
   });
 
+  describe('.render(options, cb)', function() {
+    it('should compile sass to css with file', function(done) {
+      var expected = read(fixture('simple/expected.css'), 'utf8').trim();
+      sass.render({
+        file: fixture('simple/index.scss')
+      }, function(err, result) {
+        assert.equal(result.css.trim(), expected.replace(/\r\n/g, '\n'));
+        done();
+      });
+    });
+
+    it('should throw error status 1 for bad input', function(done) {
+      sass.render({
+        data: '#navbar width 80%;'
+      }, function(err) {
+        assert(err.message);
+        assert.equal(err.status, 1);
+        done();
+      });
+    });
+  });
+
   describe('.render(importer)', function() {
     var src = read(fixture('include-files/index.scss'), 'utf8');
 


### PR DESCRIPTION
This patch and tests introduces a context for all callbacks currently
in node-sass. Right now, they run w/ an ambiguous context, making the
`this` keyword not helpful to importer developers (and eventually
custom function developers). This creates a context object, adds the
render options to said context object, and then uses that context for
importer, success, and error callbacks via `this.options`.

By using a context instead of just `.call(options...)` there is a hook
for later should we find additional environmental information is
valuable to importer / custom function developers such as the node
environment, node-sass version, etc.