### PR TITLE
Build: Uses v8 version instead of runtime name.

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -1,6 +1,4 @@
-var semver = require('semver'),
-    runtimeVersion = semver.parse(process.version),
-    fs = require('fs');
+var fs = require('fs');
 
 /**
  * Get Runtime Info
@@ -32,9 +30,7 @@ function getRuntimeInfo() {
 function getBinaryIdentifiableName() {
   return [process.platform, '-',
           process.arch, '-',
-          process.runtime.name, '-',
-          runtimeVersion.major, '.',
-          runtimeVersion.minor].join('');
+          process.versions.v8].join('');
 }
 
 process.runtime = getRuntimeInfo();

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "replace-ext": "0.0.1",
     "request": "^2.53.0",
     "sass-graph": "^1.0.3",
-    "semver": "^4.2.2",
     "shelljs": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The new binary path format is: 
`<platform>-<arch>-<v8 version>/binding.node`

Issue URL: #694.
