### PR TITLE
CLI: Retires stdout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,6 @@ Output will be saved with the same name as input SASS file into the current work
     --include-path             Path to look for imported files
     --image-path               Path to prepend when using the `image-url()` helper
     --precision                The amount of precision allowed in decimal numbers
-    --stdout                   Print the resulting CSS to stdout
     --importer                 Path to custom importer
     --help                     Print usage info
 ```

--- a/bin/node-sass
+++ b/bin/node-sass
@@ -3,7 +3,6 @@ var Emitter = require('events').EventEmitter,
     path = require('path'),
     Gaze = require('gaze'),
     meow = require('meow'),
-    replaceExt = require('replace-ext'),
     stdin = require('get-stdin'),
     grapher = require('sass-graph'),
     render = require('../lib/render');
@@ -39,7 +38,6 @@ var cli = meow({
     '  --include-path             Path to look for imported files',
     '  --image-path               Path to prepend when using the `image-url()` helper',
     '  --precision                The amount of precision allowed in decimal numbers',
-    '  --stdout                   Print the resulting CSS to stdout',
     '  --importer                 Path to custom importer',
     '  --help                     Print usage info'
   ].join('\n')
@@ -48,7 +46,6 @@ var cli = meow({
     'indented-syntax',
     'omit-source-map-url',
     'recursive',
-    'stdout',
     'source-map-embed',
     'source-map-contents',
     'source-comments'
@@ -129,21 +126,14 @@ function getEmitter() {
  */
 
 function getOptions(args, options) {
-  var dir = options.output ? path.resolve(process.cwd(), options.output) : process.cwd();
-
   options.src = args[0];
-  options.dest = args[1] ? path.resolve(dir, args[1]) : undefined;
 
-  if (!options.dest && !options.stdout) {
-    var ext = path.extname(options.src);
-    var out = path.basename(options.src);
-    var suffix = '.css';
-
-    if (ext !== suffix) {
-      out = replaceExt(out, suffix);
-    }
-
-    options.dest = path.join(dir, out);
+  if (args[1]) {
+    options.dest = path.resolve(process.cwd(), args[1]);
+  } else if (options.output) {
+    options.dest = path.join(
+      path.resolve(process.cwd(), options.output),
+      [path.basename(options.src, path.extname(options.src)), '.css'].join(''));  // replace ext.
   }
 
   return options;
@@ -208,7 +198,12 @@ function run(options, emitter) {
 
   if (options.sourceMap) {
     if (options.sourceMap === 'true') {
-      options.sourceMap = options.dest + '.map';
+      if (options.dest) {
+        options.sourceMap = options.dest + '.map';
+      } else {
+        // replace ext.
+        options.sourceMap = [path.basename(options.src, path.extname(options.src)), '.css.map'].join('');
+      }
     } else {
       options.sourceMap = path.resolve(process.cwd(), options.sourceMap);
     }

--- a/lib/render.js
+++ b/lib/render.js
@@ -42,8 +42,13 @@ module.exports = function(options, emitter) {
       }
     };
 
-    if (options.stdout || (!options.dest && !process.stdout.isTTY) || options.stdin) {
+    if (!options.dest || options.stdin) {
       emitter.emit('log', result.css);
+
+      if (options.sourceMap) {
+        emitter.emit('log', result.map);
+      }
+
       return done();
     }
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "nan": "^1.6.2",
     "npmconf": "^2.1.1",
     "object-assign": "^2.0.0",
-    "replace-ext": "0.0.1",
     "request": "^2.53.0",
     "sass-graph": "^1.0.3",
     "shelljs": "^0.3.0"

--- a/test/cli.js
+++ b/test/cli.js
@@ -11,7 +11,7 @@ describe('cli', function() {
     it('should read data from stdin', function(done) {
       var src = fs.createReadStream(fixture('simple/index.scss'));
       var expected = read(fixture('simple/expected.css'), 'utf8').trim();
-      var bin = spawn(cli, ['--stdout']);
+      var bin = spawn(cli);
 
       bin.stdout.setEncoding('utf8');
       bin.stdout.once('data', function(data) {
@@ -25,7 +25,7 @@ describe('cli', function() {
     it('should compile sass using the --indented-syntax option', function(done) {
       var src = fs.createReadStream(fixture('indent/index.sass'));
       var expected = read(fixture('indent/expected.css'), 'utf8').trim();
-      var bin = spawn(cli, ['--stdout', '--indented-syntax']);
+      var bin = spawn(cli, ['--indented-syntax']);
 
       bin.stdout.setEncoding('utf8');
       bin.stdout.once('data', function(data) {
@@ -39,7 +39,7 @@ describe('cli', function() {
     it('should compile with the --output-style option', function(done) {
       var src = fs.createReadStream(fixture('compressed/index.scss'));
       var expected = read(fixture('compressed/expected.css'), 'utf8').trim();
-      var bin = spawn(cli, ['--stdout', '--output-style', 'compressed']);
+      var bin = spawn(cli, ['--output-style', 'compressed']);
 
       bin.stdout.setEncoding('utf8');
       bin.stdout.once('data', function(data) {
@@ -53,7 +53,7 @@ describe('cli', function() {
     it('should compile with the --source-comments option', function(done) {
       var src = fs.createReadStream(fixture('source-comments/index.scss'));
       var expected = read(fixture('source-comments/expected.css'), 'utf8').trim();
-      var bin = spawn(cli, ['--stdout', '--source-comments']);
+      var bin = spawn(cli, ['--source-comments']);
 
       bin.stdout.setEncoding('utf8');
       bin.stdout.once('data', function(data) {
@@ -67,7 +67,7 @@ describe('cli', function() {
     it('should compile with the --image-path option', function(done) {
       var src = fs.createReadStream(fixture('image-path/index.scss'));
       var expected = read(fixture('image-path/expected.css'), 'utf8').trim();
-      var bin = spawn(cli, ['--stdout', '--image-path', '/path/to/images']);
+      var bin = spawn(cli, ['--image-path', '/path/to/images']);
 
       bin.stdout.setEncoding('utf8');
       bin.stdout.once('data', function(data) {
@@ -85,7 +85,7 @@ describe('cli', function() {
 
       var src = fixture('simple/index.scss');
       var dest = fixture('simple/index.css');
-      var bin = spawn(cli, [src]);
+      var bin = spawn(cli, [src, dest]);
 
       bin.on('close', function() {
         assert(fs.existsSync(dest));
@@ -118,7 +118,7 @@ describe('cli', function() {
 
       var src = fixture('include-path/index.scss');
       var expected = read(fixture('include-path/expected.css'), 'utf8').trim();
-      var bin = spawn(cli, [src, '--stdout'].concat(includePaths));
+      var bin = spawn(cli, [src].concat(includePaths));
 
       bin.stdout.setEncoding('utf8');
       bin.stdout.once('data', function(data) {
@@ -129,7 +129,7 @@ describe('cli', function() {
 
     it('should not exit with the --watch option', function(done) {
       var src = fixture('simple/index.scss');
-      var bin = spawn(cli, [src, '--stdout', '--watch']);
+      var bin = spawn(cli, [src, '--watch']);
       var exited;
 
       bin.on('close', function () {
@@ -150,7 +150,7 @@ describe('cli', function() {
       fs.writeFileSync(fixture('simple/tmp.scss'), '');
 
       var src = fixture('simple/tmp.scss');
-      var bin = spawn(cli, [src, '--stdout', '--watch']);
+      var bin = spawn(cli, [src, '--watch']);
 
       bin.stderr.setEncoding('utf8');
       bin.stderr.on('data', function(data) {
@@ -172,7 +172,7 @@ describe('cli', function() {
       var src = fixture('simple/foo.scss');
       var watched = fixture('simple/bar.scss');
       var bin = spawn(cli, [
-        src, '--stdout', '--watch', watched,
+        src, '--watch', watched,
         '--output-style', 'compressed'
       ]);
 


### PR DESCRIPTION
When no destination or output folder is provided,
it will print the output to stdout.

If the source-map option was set, it will print
it as well.

Issue URL: #669.
PR URL: #701.

//cc @xzyfer 