### PR TITLE
pangyp required at runtime for post-install from build.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,13 +55,13 @@
     "object-assign": "^2.0.0",
     "request": "^2.53.0",
     "sass-graph": "^1.0.3",
-    "shelljs": "^0.3.0"
+    "shelljs": "^0.3.0",
+    "pangyp": "^2.1.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",
     "jscoverage": "^0.5.9",
     "jshint": "^2.6.0",
-    "mocha-lcov-reporter": "^0.0.1",
-    "pangyp": "^2.1.0"
+    "mocha-lcov-reporter": "^0.0.1"
   }
 }


### PR DESCRIPTION
```
➜  tmp  npm i node-sass
|
> node-sass@2.0.1 install /Users/hugues/proj/tmp/node_modules/node-sass
> node scripts/install.js

Can not download file from https://raw.githubusercontent.com/sass/node-sass-binaries/v2.0.1/darwin-x64-iojs-1.4/binding.node

> node-sass@2.0.1 postinstall /Users/hugues/proj/tmp/node_modules/node-sass
> node scripts/build.js

module.js:322
    throw err;
          ^
Error: Cannot find module '/Users/hugues/proj/tmp/node_modules/node-sass/node_modules/pangyp/bin/node-gyp'
    at Function.Module._resolveFilename (module.js:320:15)
    at Function.Module._load (module.js:262:25)
    at Function.Module.runMain (module.js:485:10)
    at startup (node.js:112:16)
    at node.js:863:3
Build failed
```

pangyp is assumed to be installed as a local module by script/build.js.
But it is only installed for development.

This PR fixes that issue.
