### PR TITLE
postinstall fails with iojs-1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "coveralls": "^2.11.2",
     "jscoverage": "^0.5.9",
     "jshint": "^2.6.0",
-    "mocha-lcov-reporter": "^0.0.1",
-    "pangyp": "^2.1.0"
+    "mocha-lcov-reporter": "^0.0.1"
   }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -3,7 +3,7 @@ var fs = require('fs'),
     spawn = require('child_process').spawn,
     mkdir = require('mkdirp'),
     Mocha = require('mocha');
-    
+
 require('../lib/extensions');
 
 /**
@@ -50,11 +50,8 @@ function afterBuild(options) {
  */
 
 function build(options) {
-  var arguments = ['node_modules/pangyp/bin/node-gyp', 'rebuild'].concat(options.args);
-
-  console.log(['Building:', process.runtime.execPath].concat(arguments).join(' '));
-
-  var proc = spawn(process.runtime.execPath, arguments, {
+  var bin = options.platform === 'win32' ? 'node-gyp.cmd' : 'node-gyp';
+  var proc = spawn(bin, ['rebuild'].concat(options.args), {
     stdio: [0, 1, 2]
   });
 


### PR DESCRIPTION
I encountered the same error than kevinSuttle here: https://github.com/sass/node-sass/issues/693#issuecomment-76340269

iojs-1.4.1 installed via nvm.

```
➜  tmp  npm i node-sass
|
> node-sass@2.0.1 install /Users/hugues/proj/tmp/node_modules/node-sass
> node scripts/install.js

Can not download file from https://raw.githubusercontent.com/sass/node-sass-binaries/v2.0.1/darwin-x64-iojs-1.4/binding.node

> node-sass@2.0.1 postinstall /Users/hugues/proj/tmp/node_modules/node-sass
> node scripts/build.js

module.js:322
    throw err;
          ^
Error: Cannot find module '/Users/hugues/proj/tmp/node_modules/node-sass/node_modules/pangyp/bin/node-gyp'
    at Function.Module._resolveFilename (module.js:320:15)
    at Function.Module._load (module.js:262:25)
    at Function.Module.runMain (module.js:485:10)
    at startup (node.js:112:16)
    at node.js:863:3
Build failed
```

On my Macos machine there is no homebrew installation of nodejs or iojs; it is important because homebrew does not install the proper patched npm for iojs and one ends-up having to use pangyp as an alternative to node-gyp when that happens.

The stack trace shows that pangyp, a devDependency, was not installed.
So I moved pangyp to a runtime dependency and got past that problem: https://github.com/sass/node-sass/pull/714#issuecomment-76371437

However the sass binary produced remained incompatible.

I have reverted the use of pangyp (https://github.com/hmalphettes/node-sass/commit/5a113952bf517ebb96f50204431b8f2d8844500d) and put back node-gyp and everything is working like a charm.