### PR TITLE
Code: Formats and fixes JSCS warnings

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+node_modules/**

--- a/bin/node-sass
+++ b/bin/node-sass
@@ -98,11 +98,11 @@ function getEmitter() {
     }
   });
 
-  emitter.on('warn', function(data){
+  emitter.on('warn', function(data) {
     console.warn(data);
   });
 
-  emitter.on('log', function(data){
+  emitter.on('log', function(data) {
     console.log(data);
   });
 

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -41,7 +41,7 @@ function getSassInfo() {
   return [
            ['node-sass', package.version, '(Wrapper)', '[JavaScript]'].join('\t'),
            ['libsass  ', package.libsass, '(Sass Compiler)', '[C/C++]'].join('\t'),
-         ].join(eol);
+  ].join(eol);
 }
 
 process.runtime = getRuntimeInfo();

--- a/lib/index.js
+++ b/lib/index.js
@@ -245,7 +245,7 @@ module.exports.renderSync = function(options) {
   var status = options.data ? binding.renderSync(options) : binding.renderFileSync(options);
   var result = options.result;
 
-  if(status) {
+  if (status) {
     result.stats = endStats(result.stats);
     return result;
   }

--- a/lib/render.js
+++ b/lib/render.js
@@ -58,7 +58,7 @@ module.exports = function(options, emitter) {
         return emitter.emit('error', chalk.red(err));
       }
 
-      fs.writeFile(options.dest, result.css, function (err) {
+      fs.writeFile(options.dest, result.css, function(err) {
         if (err) {
           return emitter.emit('error', chalk.red(err));
         }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "description": "Wrapper around libsass",
   "license": "MIT",
   "homepage": "https://github.com/sass/node-sass",
-  "repository": "sass/node-sass",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sass/node-sass"
+  },
   "author": {
     "name": "Andrew Nesbitt",
     "email": "andrewnez@gmail.com",
@@ -54,8 +57,7 @@
     "object-assign": "^2.0.0",
     "pangyp": "^2.1.0",
     "request": "^2.53.0",
-    "sass-graph": "^1.0.3",
-    "shelljs": "^0.3.0"
+    "sass-graph": "^1.0.3"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -18,19 +18,19 @@ function afterBuild(options) {
   var target = path.join(__dirname, '..', 'build', folder, 'binding.node');
   var install = path.join(__dirname, '..', 'vendor', process.sassBinaryName, 'binding.node');
 
-  mkdir(path.join(__dirname, '..', 'vendor', process.sassBinaryName), function (err) {
+  mkdir(path.join(__dirname, '..', 'vendor', process.sassBinaryName), function(err) {
     if (err && err.code !== 'EEXIST') {
       console.error(err.message);
       return;
     }
 
-    fs.stat(target, function (err) {
+    fs.stat(target, function(err) {
       if (err) {
         console.error('Build succeeded but target not found');
         return;
       }
 
-      fs.rename(target, install, function (err) {
+      fs.rename(target, install, function(err) {
         if (err) {
           console.error(err.message);
           return;
@@ -110,7 +110,7 @@ function testBinary(options) {
     return build(options);
   }
 
-  fs.stat(path.join(__dirname, '..', 'vendor', process.sassBinaryName, 'binding.node'), function (err) {
+  fs.stat(path.join(__dirname, '..', 'vendor', process.sassBinaryName, 'binding.node'), function(err) {
     if (err) {
       return build(options);
     }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -2,7 +2,6 @@ var fs = require('fs'),
     path = require('path'),
     request = require('request'),
     mkdirp = require('mkdirp'),
-    exec = require('shelljs').exec,
     npmconf = require('npmconf'),
     packageInfo = require('../package.json');
 

--- a/test/api.js
+++ b/test/api.js
@@ -430,7 +430,7 @@ describe('api', function() {
   describe('.renderSync(options)', function() {
     it('should compile sass to css with file', function(done) {
       var expected = read(fixture('simple/expected.css'), 'utf8').trim();
-      var result = sass.renderSync({file: fixture('simple/index.scss')});
+      var result = sass.renderSync({ file: fixture('simple/index.scss') });
 
       assert.equal(result.css.trim(), expected.replace(/\r\n/g, '\n'));
       done();
@@ -472,7 +472,7 @@ describe('api', function() {
     it('should compile sass to css with data', function(done) {
       var src = read(fixture('simple/index.scss'), 'utf8');
       var expected = read(fixture('simple/expected.css'), 'utf8').trim();
-      var result = sass.renderSync({data: src});
+      var result = sass.renderSync({ data: src });
 
       assert.equal(result.css.trim(), expected.replace(/\r\n/g, '\n'));
       done();
@@ -492,7 +492,7 @@ describe('api', function() {
 
     it('should throw error for bad input', function(done) {
       assert.throws(function() {
-        sass.renderSync({data: '#navbar width 80%;'});
+        sass.renderSync({ data: '#navbar width 80%;' });
       });
 
       done();

--- a/test/cli.js
+++ b/test/cli.js
@@ -118,7 +118,7 @@ describe('cli', function() {
       var bin = spawn(cli, [src, '--watch']);
       var exited;
 
-      bin.on('close', function () {
+      bin.on('close', function() {
         exited = true;
       });
 
@@ -198,7 +198,7 @@ describe('cli', function() {
       var expectedMap = read(fixture('source-map/expected.map'), 'utf8').trim().replace(/\r\n/g, '\n');
       var bin = spawn(cli, [src, '--output', path.dirname(destCss), '--source-map', destMap]);
 
-      bin.on('close', function () {
+      bin.on('close', function() {
         assert.equal(read(destCss, 'utf8').trim(), expectedCss);
         assert.equal(read(destMap, 'utf8').trim(), expectedMap);
         fs.unlinkSync(destMap);
@@ -216,7 +216,7 @@ describe('cli', function() {
         '--source-map', map, '--omit-source-map-url'
       ]);
 
-      bin.on('close', function () {
+      bin.on('close', function() {
         assert(read(dest, 'utf8').indexOf('sourceMappingURL') === -1);
         assert(fs.existsSync(map));
         fs.unlinkSync(map);
@@ -257,7 +257,7 @@ describe('cli', function() {
         '--importer', fixture('extras/my_custom_importer_file_and_data_cb.js')
       ]);
 
-      bin.on('close', function () {
+      bin.on('close', function() {
         assert.equal(read(dest, 'utf8').trim(), expected);
         fs.unlinkSync(dest);
         done();
@@ -270,7 +270,7 @@ describe('cli', function() {
         '--importer', fixture('extras/my_custom_importer_file_cb.js')
       ]);
 
-      bin.on('close', function () {
+      bin.on('close', function() {
         if (fs.existsSync(dest)) {
           assert.equal(read(dest, 'utf8').trim(), '');
           fs.unlinkSync(dest);
@@ -286,7 +286,7 @@ describe('cli', function() {
         '--importer', fixture('extras/my_custom_importer_data_cb.js')
       ]);
 
-      bin.on('close', function () {
+      bin.on('close', function() {
         assert.equal(read(dest, 'utf8').trim(), expected);
         fs.unlinkSync(dest);
         done();
@@ -299,7 +299,7 @@ describe('cli', function() {
         '--importer', fixture('extras/my_custom_importer_file_and_data.js')
       ]);
 
-      bin.on('close', function () {
+      bin.on('close', function() {
         assert.equal(read(dest, 'utf8').trim(), expected);
         fs.unlinkSync(dest);
         done();
@@ -312,7 +312,7 @@ describe('cli', function() {
         '--importer', fixture('extras/my_custom_importer_file.js')
       ]);
 
-      bin.on('close', function () {
+      bin.on('close', function() {
         if (fs.existsSync(dest)) {
           assert.equal(read(dest, 'utf8').trim(), '');
           fs.unlinkSync(dest);
@@ -328,7 +328,7 @@ describe('cli', function() {
         '--importer', fixture('extras/my_custom_importer_data.js')
       ]);
 
-      bin.on('close', function () {
+      bin.on('close', function() {
         assert.equal(read(dest, 'utf8').trim(), expected);
         fs.unlinkSync(dest);
         done();
@@ -341,7 +341,7 @@ describe('cli', function() {
         '--importer', fixture('non/existing/path')
       ]);
 
-      bin.on('close', function (code) {
+      bin.on('close', function(code) {
         assert(code !== 0);
         done();
       });

--- a/test/fixtures/extras/my_custom_importer_data.js
+++ b/test/fixtures/extras/my_custom_importer_data.js
@@ -1,5 +1,5 @@
 module.exports = function() {
   return {
-      contents: 'div {color: yellow;}'
+    contents: 'div {color: yellow;}'
   };
 };

--- a/test/fixtures/extras/my_custom_importer_data_cb.js
+++ b/test/fixtures/extras/my_custom_importer_data_cb.js
@@ -1,5 +1,5 @@
 module.exports = function(file, prev, done) {
   done({
-      contents: 'div {color: yellow;}'
+    contents: 'div {color: yellow;}'
   });
 };

--- a/test/fixtures/extras/my_custom_importer_file.js
+++ b/test/fixtures/extras/my_custom_importer_file.js
@@ -2,6 +2,6 @@ var path = require('path');
 
 module.exports = function(file) {
   return {
-      file: path.resolve(path.join(process.cwd(), 'test/fixtures/include-files/', file + (path.extname(file) ? '' : '.scss')))
+    file: path.resolve(path.join(process.cwd(), 'test/fixtures/include-files/', file + (path.extname(file) ? '' : '.scss')))
   };
 };

--- a/test/fixtures/extras/my_custom_importer_file_and_data.js
+++ b/test/fixtures/extras/my_custom_importer_file_and_data.js
@@ -1,6 +1,6 @@
 module.exports = function() {
   return {
-      file: '/some/random/path/file.scss',
-      contents: 'div {color: yellow;}'
+    file: '/some/random/path/file.scss',
+    contents: 'div {color: yellow;}'
   };
 };

--- a/test/fixtures/extras/my_custom_importer_file_and_data_cb.js
+++ b/test/fixtures/extras/my_custom_importer_file_and_data_cb.js
@@ -1,6 +1,6 @@
 module.exports = function(file, prev, done) {
   done({
-      file: '/some/random/path/file.scss',
-      contents: 'div {color: yellow;}'
+    file: '/some/random/path/file.scss',
+    contents: 'div {color: yellow;}'
   });
 };

--- a/test/fixtures/extras/my_custom_importer_file_cb.js
+++ b/test/fixtures/extras/my_custom_importer_file_cb.js
@@ -2,6 +2,6 @@ var path = require('path');
 
 module.exports = function(file, /* jshint unused:false */ prev, done) {
   done({
-      file: path.resolve(path.join(process.cwd(), 'test/fixtures/include-files/', file + (path.extname(file) ? '' : '.scss')))
+    file: path.resolve(path.join(process.cwd(), 'test/fixtures/include-files/', file + (path.extname(file) ? '' : '.scss')))
   });
 };

--- a/test/spec.js
+++ b/test/spec.js
@@ -6,12 +6,12 @@ var assert = require('assert'),
     sass = require('../lib'),
     util = require('./util');
 
-describe('spec', function () {
+describe('spec', function() {
   var suites = util.getSuites();
 
   describe('test/sass-spec directory', function() {
     it('should be a cloned into place', function(done) {
-      fs.exists(path.join(__dirname, 'fixtures', 'spec'), function (exists) {
+      fs.exists(path.join(__dirname, 'fixtures', 'spec'), function(exists) {
         if (!exists) {
           throw new Error([
             'test/fixtures/spec directory missing. Please clone it into place by',
@@ -29,7 +29,7 @@ describe('spec', function () {
   Object.keys(suites).forEach(function(suite) {
     var tests = Object.keys(suites[suite]);
 
-    describe(suite, function () {
+    describe(suite, function() {
       tests.forEach(function(test) {
         var t = suites[suite][test];
 


### PR DESCRIPTION
* Code: Formats and fixes JSCS warnings. …  
  * Removes unused pacakge `shelljs`.
  * Fixes package.json validation issue reported
    by WE2013, based on njs package.json schema:

    > *The value property "repository" must be of
     type "Object", but was "sass/node-sass"*

* Repo: Adds .jshintignore.
  * To avoid validating node_modules directory.

