### PR TITLE
Build: Implements GH API to upload binaries

### DIFF
--- a/scripts/upload.js
+++ b/scripts/upload.js
@@ -1,0 +1,86 @@
+/*!
+ * node-sass: scripts/upload.js
+ */
+require('../lib/extensions');
+
+var flags = require('meow')({ pkg: '../' }).flags;
+
+var fetchReleaseInfoUrl = ['https://api.github.com/repos/sass/node-sass/releases/tags/v',
+                           flags.tag ? flags.tag : require('../package.json').version].join(''),
+    file = flags.path ?
+             flags.path :
+             require('path').resolve(__dirname, '..', 'vendor', process.sassBinaryName, 'binding.node'),
+    fs = require('fs'),
+    os = require('os'),
+    request = require('request'),
+    uploadReleaseAssetUrl = ['?name=', process.sassBinaryName, '.node', '&label=', process.sassBinaryName].join('');
+
+/**
+ * Upload binary using GitHub API
+ *
+ * @api private
+ */
+
+function uploadBinary() {
+  if (!fs.existsSync(file)) {
+    throw new Error('Error reading file.');
+  }
+
+  var post = function() {
+    request.post({
+      url: uploadReleaseAssetUrl,
+      headers: {
+        'Authorization': ['Token ', flags.auth].join(''),
+        'Content-Type': 'application/octet-stream'
+      },
+      formData: {
+        file: fs.createReadStream(file)
+      }
+    }, function(err, res, body) {
+      if (err) {
+        throwFormattedError(err);
+      }
+
+      var formattedResponse = JSON.parse(body);
+
+      if (formattedResponse.errors) {
+        throwFormattedError(formattedResponse.errors);
+      }
+
+      console.log(['Binary uploaded successfully.',
+                   'Please test the following link before announcement it:',
+                   formattedResponse.browser_download_url].join(os.EOL));
+    });
+  };
+
+  request.get({
+    url: fetchReleaseInfoUrl,
+    headers: {
+      'User-Agent': 'Node-Sass-Release-Agent'
+    }
+  }, function(err, res, body) {
+    if (err) {
+      throw new Error('Error fetching release id.');
+    }
+
+    var upload_url = JSON.parse(body).upload_url;
+    uploadReleaseAssetUrl = upload_url.replace(/{\?name}/, uploadReleaseAssetUrl);
+
+    console.log('Upload URL is:', uploadReleaseAssetUrl);
+
+    post();
+  });
+}
+
+function throwFormattedError(err) {
+  throw new Error([
+    'Error uploading release asset.',
+    'The server returned:', JSON.stringify(err)].join(os.EOL));
+}
+
+/**
+ * Run
+ */
+
+console.log('Preparing to uploading', file, '..');
+uploadBinary();


### PR DESCRIPTION
This is first in the series of overhauling build steps. Find the related discussion at: https://github.com/sass/node-sass/issues/712.

The public access token can be generated from: https://github.com/settings/applications#personal-access-tokens.

#### Usage:

Anyone with write-access to sass/node-sass can run:

> node scripts/upload --auth MyGitHubOAuthToken

This will upload the binary file to the latest release (for instance, current is v2.0.1).

To upload the asset to specific release:

> node scripts/upload --auth MyGitHubOAuthToken --tag 2.0.0

To upload the asset from a custom paths:

> node scripts/upload --auth MyGitHubOAuthToken --path ~/docs/my_emails/someoneITrust/blah.node

//cc @nschonni, @xzyfer 