### PR TITLE
Update process spawning in coverage.js for mocha 2.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "cross-spawn": "^0.2.6",
     "jscoverage": "^0.5.9",
     "jshint": "^2.6.3",
-    "mocha": "^2.2.0",
+    "mocha": "^2.2.1",
     "mocha-lcov-reporter": "^0.0.2"
   }
 }

--- a/scripts/coverage.js
+++ b/scripts/coverage.js
@@ -12,7 +12,9 @@ function suite() {
   process.env.NODESASS_COV = 1;
 
   var coveralls = spawn(bin('coveralls'));
-  var mocha = spawn(bin('_mocha'), ['--reporter', 'mocha-lcov-reporter'], {
+
+  var args = [bin('_mocha')].concat(['--reporter', 'mocha-lcov-reporter']);
+  var mocha = spawn(process.execPath, args, {
     env: process.env
   });
 


### PR DESCRIPTION
Bumps mocha to 2.2.1, and fixes the error highlighted in https://github.com/mochajs/mocha/issues/1585:
```
0.80s$ npm run-script coverage
> node-sass@2.0.1 coverage /home/travis/build/sass/node-sass
> node scripts/coverage.js
/home/travis/build/sass/node-sass/node_modules/.bin/_mocha: 1: /home/travis/build/sass/node-sass/node_modules/.bin/_mocha: /bin: Permission denied
npm ERR! node-sass@2.0.1 coverage: `node scripts/coverage.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the node-sass@2.0.1 coverage script.
npm ERR! This is most likely a problem with the node-sass package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node scripts/coverage.js
npm ERR! You can get their info via:
npm ERR!     npm owner ls node-sass
npm ERR! There is likely additional logging output above.
npm ERR! System Linux 2.6.32-042stab090.5
npm ERR! command "/home/travis/.nvm/v0.10.36/bin/node" "/home/travis/.nvm/v0.10.36/bin/npm" "run-script" "coverage"
npm ERR! cwd /home/travis/build/sass/node-sass
npm ERR! node -v v0.10.36
npm ERR! npm -v 1.4.28
npm ERR! code ELIFECYCLE
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /home/travis/build/sass/node-sass/npm-debug.log
npm ERR! not ok code 0
````