### PR TITLE
Build with the unbundled libsass

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,56 +4,43 @@
       'target_name': 'binding',
       'sources': [
         'src/binding.cpp',
-        'src/sass_context_wrapper.cpp',
-        'src/libsass/ast.cpp',
-        'src/libsass/base64vlq.cpp',
-        'src/libsass/bind.cpp',
-        'src/libsass/cencode.c',
-        'src/libsass/constants.cpp',
-        'src/libsass/context.cpp',
-        'src/libsass/contextualize.cpp',
-        'src/libsass/copy_c_str.cpp',
-        'src/libsass/error_handling.cpp',
-        'src/libsass/eval.cpp',
-        'src/libsass/expand.cpp',
-        'src/libsass/extend.cpp',
-        'src/libsass/file.cpp',
-        'src/libsass/functions.cpp',
-        'src/libsass/inspect.cpp',
-        'src/libsass/json.cpp',
-        'src/libsass/node.cpp',
-        'src/libsass/output_compressed.cpp',
-        'src/libsass/output_nested.cpp',
-        'src/libsass/parser.cpp',
-        'src/libsass/prelexer.cpp',
-        'src/libsass/remove_placeholders.cpp',
-        'src/libsass/sass.cpp',
-        'src/libsass/sass2scss.cpp',
-        'src/libsass/sass_context.cpp',
-        'src/libsass/sass_functions.cpp',
-        'src/libsass/sass_util.cpp',
-        'src/libsass/sass_values.cpp',
-        'src/libsass/source_map.cpp',
-        'src/libsass/to_c.cpp',
-        'src/libsass/to_string.cpp',
-        'src/libsass/units.cpp',
-        'src/libsass/utf8_string.cpp',
-        'src/libsass/util.cpp'
+        'src/sass_context_wrapper.cpp'
       ],
       'include_dirs': [
-        '<!(node -e "require(\'nan\')")'
-      ],
-      'cflags!': [
-        '-fno-exceptions'
-      ],
-      'cflags_cc!': [
-        '-fno-exceptions'
-      ],
-      'cflags_cc': [
-        '-fexceptions',
-        '-frtti'
+        '<!(node -e "require(\'nan\')")',
       ],
       'conditions': [
+        ['libsass_ext == ""', {
+            'dependencies': [
+              'libsass.gyp:libsass',
+            ]
+        }],
+	['libsass_ext == "auto"', {
+	  'cflags_cc': [
+	    '<!(pkg-config --cflags libsass)',
+	  ],
+	  'link_settings': {
+	    'ldflags': [
+	      '<!(pkg-config --libs-only-other --libs-only-L libsass)',
+	    ],
+	    'libraries': [
+	      '<!(pkg-config --libs-only-l libsass)',
+	    ],
+	  }
+	}],
+	['libsass_ext == "yes"', {
+	  'cflags_cc': [
+	    '<(libsass_cflags)',
+	  ],
+	  'link_settings': {
+	    'ldflags': [
+	      '<(libsass_ldflags)',
+	    ],
+	    'libraries': [
+	      '<(libsass_library)',
+	    ],
+	  }
+        }],
         ['OS=="mac"', {
           'xcode_settings': {
             'OTHER_CPLUSPLUSFLAGS': [
@@ -67,7 +54,7 @@
             'GCC_ENABLE_CPP_RTTI': 'YES',
             'MACOSX_DEPLOYMENT_TARGET': '10.7'
           }
-         }],
+        }],
         ['OS=="win"', {
           'msvs_settings': {
             'VCCLCompilerTool': {

--- a/libsass.gyp
+++ b/libsass.gyp
@@ -1,0 +1,94 @@
+{
+  'targets': [
+    {
+      'target_name': 'libsass',
+      'type': 'static_library',
+      'sources': [
+        'src/libsass/ast.cpp',
+        'src/libsass/base64vlq.cpp',
+        'src/libsass/bind.cpp',
+        'src/libsass/cencode.c',
+        'src/libsass/constants.cpp',
+        'src/libsass/context.cpp',
+        'src/libsass/contextualize.cpp',
+        'src/libsass/copy_c_str.cpp',
+        'src/libsass/error_handling.cpp',
+        'src/libsass/eval.cpp',
+        'src/libsass/expand.cpp',
+        'src/libsass/extend.cpp',
+        'src/libsass/file.cpp',
+        'src/libsass/functions.cpp',
+        'src/libsass/inspect.cpp',
+        'src/libsass/json.cpp',
+        'src/libsass/node.cpp',
+        'src/libsass/output_compressed.cpp',
+        'src/libsass/output_nested.cpp',
+        'src/libsass/parser.cpp',
+        'src/libsass/prelexer.cpp',
+        'src/libsass/remove_placeholders.cpp',
+        'src/libsass/sass.cpp',
+        'src/libsass/sass2scss.cpp',
+        'src/libsass/sass_context.cpp',
+        'src/libsass/sass_functions.cpp',
+        'src/libsass/sass_util.cpp',
+        'src/libsass/sass_values.cpp',
+        'src/libsass/source_map.cpp',
+        'src/libsass/to_c.cpp',
+        'src/libsass/to_string.cpp',
+        'src/libsass/units.cpp',
+        'src/libsass/utf8_string.cpp',
+        'src/libsass/util.cpp'
+      ],
+      'cflags!': [
+        '-fno-exceptions'
+      ],
+      'cflags_cc!': [
+        '-fno-exceptions'
+      ],
+      'cflags_cc': [
+        '-fexceptions',
+        '-frtti'
+      ],
+      'direct_dependent_settings': {
+        'include_dirs': [ 'src/libsass' ],
+      },
+      'conditions': [
+        ['OS=="mac"', {
+          'xcode_settings': {
+            'OTHER_CPLUSPLUSFLAGS': [
+              '-std=c++11',
+              '-stdlib=libc++'
+            ],
+            'OTHER_LDFLAGS': [
+              '-stdlib=libc++'
+            ],
+            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+            'GCC_ENABLE_CPP_RTTI': 'YES',
+            'MACOSX_DEPLOYMENT_TARGET': '10.7'
+          }
+         }],
+        ['OS=="win"', {
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              'AdditionalOptions': [
+                '/GR',
+                '/EHsc'
+              ]
+            }
+          },
+          'msvs_disabled_warnings': [
+            # conversion from `double` to `size_t`, possible loss of data
+            4244,
+            # decorated name length exceeded
+            4503
+          ]
+        }],
+        ['OS!="win"', {
+          'cflags_cc+': [
+            '-std=c++0x'
+          ]
+        }]
+      ]
+    }
+  ]
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -53,7 +53,15 @@ function afterBuild(options) {
  */
 
 function build(options) {
-  var arguments = [path.join('node_modules', 'pangyp', 'bin', 'node-gyp'), 'rebuild'].concat(options.args);
+  var arguments = [
+    path.join('node_modules', 'pangyp', 'bin', 'node-gyp'),
+    'rebuild',
+  ].concat(
+    [ 'libsass_ext', 'libsass_cflags',
+      'libsass_ldflags', 'libsass_library' ].map(function(subject) {
+      return ['--', subject, '=', process.env[subject.toUpperCase()] || ''].join('');
+    })
+  ).concat(options.args);
 
   console.log(['Building:', process.sass.runtime.execPath].concat(arguments).join(' '));
 

--- a/src/sass_context_wrapper.h
+++ b/src/sass_context_wrapper.h
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 #include <nan.h>
 #include <condition_variable>
-#include "libsass/sass_context.h"
+#include <sass_context.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
If PKGCONFIG is set to YES in the proces
environment, use pkg-config to locate
system libsass to be linked.

This way there is no need to checkout
a src/libsass submodule at all and
the library from the package management
system can be used.

Otherwise fallback to the bundled libsass.

By default, use the bundled library.

PR: #139
PR: #389
PR: #744