### PR TITLE
scripts: don't rely on pangyp being a direct dependency

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -54,7 +54,7 @@ function afterBuild(options) {
 
 function build(options) {
   var args = [
-    path.join('node_modules', 'pangyp', 'bin', 'node-gyp'),
+    path.join(require.resolve('pangyp'), '../../bin/node-gyp.js'),
     'rebuild',
   ].concat(
     [ 'libsass_ext', 'libsass_cflags',


### PR DESCRIPTION
getting this error:

```bash
> node-sass@2.0.1 postinstall /Users/jong/Workspace/my-package/node_modules/grunt-sass/node_modules/node-sass
> node scripts/build.js

module.js:318
    throw err;
          ^
Error: Cannot find module '/Users/jong/Workspace/my-package/node_modules/grunt-sass/node_modules/node-sass/node_modules/pangyp/bin/node-gyp'
    at Function.Module._resolveFilename (module.js:316:15)
    at Function.Module._load (module.js:258:25)
    at Function.Module.runMain (module.js:451:10)
    at startup (node.js:123:18)
    at node.js:868:3
Build failed
```

this may fix it