### PR TITLE
remove extra slash to fix binary download fail

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -89,7 +89,7 @@ function getBinaryUrl() {
   return flags['--sass-binary-url'] ||
          package.nodeSassConfig ? package.nodeSassConfig.binaryUrl : null ||
          process.env.SASS_BINARY_URL ||
-         ['https://github.com/sass/node-sass/releases/download//v',
+         ['https://github.com/sass/node-sass/releases/download/v',
           package.version, '/', sass.binaryName].join('');
 }
 


### PR DESCRIPTION
The extra slash was causing the binary download to fail - this was the commit where it was added - https://github.com/sass/node-sass/commit/2220ba96b9a20920ccfaaadc12978f40e069caf9