### PR TITLE
Code: Reverted #763

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,6 +8,42 @@
         'src/custom_function_bridge.cpp',
         'src/custom_importer_bridge.cpp',
         'src/sass_context_wrapper.cpp',
+        'src/libsass/ast.cpp',
+        'src/libsass/base64vlq.cpp',
+        'src/libsass/bind.cpp',
+        'src/libsass/cencode.c',
+        'src/libsass/constants.cpp',
+        'src/libsass/context.cpp',
+        'src/libsass/contextualize.cpp',
+        'src/libsass/cssize.cpp',
+        'src/libsass/emitter.cpp',
+        'src/libsass/error_handling.cpp',
+        'src/libsass/eval.cpp',
+        'src/libsass/expand.cpp',
+        'src/libsass/extend.cpp',
+        'src/libsass/file.cpp',
+        'src/libsass/functions.cpp',
+        'src/libsass/inspect.cpp',
+        'src/libsass/json.cpp',
+        'src/libsass/node.cpp',
+        'src/libsass/output.cpp',
+        'src/libsass/parser.cpp',
+        'src/libsass/plugins.cpp',
+        'src/libsass/position.cpp',
+        'src/libsass/prelexer.cpp',
+        'src/libsass/remove_placeholders.cpp',
+        'src/libsass/sass.cpp',
+        'src/libsass/sass2scss.cpp',
+        'src/libsass/sass_context.cpp',
+        'src/libsass/sass_functions.cpp',
+        'src/libsass/sass_util.cpp',
+        'src/libsass/sass_values.cpp',
+        'src/libsass/source_map.cpp',
+        'src/libsass/to_c.cpp',
+        'src/libsass/to_string.cpp',
+        'src/libsass/units.cpp',
+        'src/libsass/utf8_string.cpp',
+        'src/libsass/util.cpp',
         'src/sass_types/boolean.cpp',
         'src/sass_types/color.cpp',
         'src/sass_types/error.cpp',
@@ -21,38 +57,17 @@
       'include_dirs': [
         '<!(node -e "require(\'nan\')")',
       ],
+      'cflags!': [
+        '-fno-exceptions'
+      ],
+      'cflags_cc!': [
+        '-fno-exceptions'
+      ],
+      'cflags_cc': [
+        '-fexceptions',
+        '-frtti'
+      ],
       'conditions': [
-        ['libsass_ext == ""', {
-            'dependencies': [
-              'libsass.gyp:libsass',
-            ]
-        }],
-        ['libsass_ext == "auto"', {
-          'cflags_cc': [
-            '<!(pkg-config --cflags libsass)',
-          ],
-          'link_settings': {
-            'ldflags': [
-              '<!(pkg-config --libs-only-other --libs-only-L libsass)',
-            ],
-            'libraries': [
-              '<!(pkg-config --libs-only-l libsass)',
-            ],
-          }
-        }],
-        ['libsass_ext == "yes"', {
-          'cflags_cc': [
-            '<(libsass_cflags)',
-          ],
-          'link_settings': {
-            'ldflags': [
-              '<(libsass_ldflags)',
-            ],
-            'libraries': [
-              '<(libsass_library)',
-            ],
-          }
-        }],
         ['OS=="mac"', {
           'xcode_settings': {
             'OTHER_CPLUSPLUSFLAGS': [

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "bin",
     "binding.gyp",
     "lib",
-    "libsass.gyp",
     "scripts",
     "src"
   ],

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -53,10 +53,7 @@ function afterBuild(options) {
  */
 
 function build(options) {
-  var args = [path.join('node_modules', 'pangyp', 'bin', 'node-gyp'), 'rebuild'].concat(
-    ['libsass_ext', 'libsass_cflags', 'libsass_ldflags', 'libsass_library'].map(function(subject) {
-      return ['--', subject, '=', process.env[subject.toUpperCase()] || ''].join('');
-    })).concat(options.args);
+  var args = [path.join('node_modules', 'pangyp', 'bin', 'node-gyp'), 'rebuild'].concat(options.args);
 
   console.log(['Building:', process.sass.runtime.execPath].concat(args).join(' '));
 

--- a/src/custom_function_bridge.cpp
+++ b/src/custom_function_bridge.cpp
@@ -1,6 +1,5 @@
 #include <nan.h>
 #include "custom_function_bridge.h"
-#include <sass_context.h>
 #include "sass_types/factory.h"
 
 Sass_Value* CustomFunctionBridge::post_process_return_value(Handle<Value> val) const {

--- a/src/custom_function_bridge.h
+++ b/src/custom_function_bridge.h
@@ -2,8 +2,8 @@
 #define CUSTOM_FUNCTION_BRIDGE_H
 
 #include <nan.h>
+#include "libsass/sass_context.h"
 #include "callback_bridge.h"
-#include <sass_context.h>
 
 
 using namespace v8;

--- a/src/custom_importer_bridge.cpp
+++ b/src/custom_importer_bridge.cpp
@@ -1,5 +1,4 @@
 #include <nan.h>
-#include <sass_context.h>
 #include "custom_importer_bridge.h"
 #include "create_string.h"
 

--- a/src/custom_importer_bridge.h
+++ b/src/custom_importer_bridge.h
@@ -2,7 +2,7 @@
 #define CUSTOM_IMPORTER_BRIDGE_H
 
 #include <nan.h>
-#include <sass_context.h>
+#include "libsass/sass_context.h"
 #include "callback_bridge.h"
 
 

--- a/src/sass_context_wrapper.h
+++ b/src/sass_context_wrapper.h
@@ -5,7 +5,7 @@
 #include <nan.h>
 #include <stdlib.h>
 #include <condition_variable>
-#include <sass_context.h>
+#include "libsass/sass_context.h"
 #include "custom_function_bridge.h"
 #include "custom_importer_bridge.h"
 

--- a/src/sass_types/boolean.cpp
+++ b/src/sass_types/boolean.cpp
@@ -1,7 +1,5 @@
 #include <nan.h>
-#include <sass_values.h>
 #include "boolean.h"
-#include "sass_value_wrapper.h"
 
 using namespace v8;
 

--- a/src/sass_types/boolean.h
+++ b/src/sass_types/boolean.h
@@ -2,14 +2,13 @@
 #define SASS_TYPES_BOOLEAN_H
 
 #include <nan.h>
-#include <sass_values.h>
 #include "value.h"
+#include "sass_value_wrapper.h"
 
-
-namespace SassTypes 
+namespace SassTypes
 {
   using namespace v8;
-  
+
   class Boolean : public Value {
     public:
       static Boolean& get_singleton(bool);
@@ -31,6 +30,5 @@ namespace SassTypes
       static bool constructor_locked;
   };
 }
-
 
 #endif

--- a/src/sass_types/color.cpp
+++ b/src/sass_types/color.cpp
@@ -1,7 +1,5 @@
 #include <nan.h>
-#include <sass_values.h>
 #include "color.h"
-#include "sass_value_wrapper.h"
 
 using namespace v8;
 

--- a/src/sass_types/color.h
+++ b/src/sass_types/color.h
@@ -2,14 +2,12 @@
 #define SASS_TYPES_COLOR_H
 
 #include <nan.h>
-#include <sass_values.h>
 #include "sass_value_wrapper.h"
 
-
-namespace SassTypes 
+namespace SassTypes
 {
   using namespace v8;
-  
+
   class Color : public SassValueWrapper<Color> {
     public:
       Color(Sass_Value*);
@@ -28,6 +26,5 @@ namespace SassTypes
       static NAN_METHOD(SetA);
   };
 }
-
 
 #endif

--- a/src/sass_types/error.cpp
+++ b/src/sass_types/error.cpp
@@ -1,8 +1,6 @@
 #include <nan.h>
-#include <sass_values.h>
 #include "error.h"
 #include "../create_string.h"
-#include "sass_value_wrapper.h"
 
 using namespace v8;
 

--- a/src/sass_types/error.h
+++ b/src/sass_types/error.h
@@ -2,14 +2,12 @@
 #define SASS_TYPES_ERROR_H
 
 #include <nan.h>
-#include <sass_values.h>
 #include "sass_value_wrapper.h"
 
-
-namespace SassTypes 
+namespace SassTypes
 {
   using namespace v8;
-  
+
   class Error : public SassValueWrapper<Error> {
     public:
       Error(Sass_Value*);

--- a/src/sass_types/factory.cpp
+++ b/src/sass_types/factory.cpp
@@ -1,6 +1,5 @@
 #include <nan.h>
 #include "factory.h"
-#include <sass_values.h>
 #include "value.h"
 #include "number.h"
 #include "string.h"

--- a/src/sass_types/factory.h
+++ b/src/sass_types/factory.h
@@ -2,7 +2,7 @@
 #define SASS_TYPES_FACTORY_H
 
 #include <nan.h>
-#include <sass_values.h>
+#include "../libsass/sass_values.h"
 #include "value.h"
 
 namespace SassTypes

--- a/src/sass_types/list.cpp
+++ b/src/sass_types/list.cpp
@@ -1,7 +1,5 @@
 #include <nan.h>
-#include <sass_values.h>
 #include "list.h"
-#include "sass_value_wrapper.h"
 
 using namespace v8;
 

--- a/src/sass_types/list.h
+++ b/src/sass_types/list.h
@@ -2,14 +2,12 @@
 #define SASS_TYPES_LIST_H
 
 #include <nan.h>
-#include <sass_values.h>
 #include "sass_value_wrapper.h"
 
-
-namespace SassTypes 
+namespace SassTypes
 {
   using namespace v8;
-  
+
   class List : public SassValueWrapper<List> {
     public:
       List(Sass_Value*);

--- a/src/sass_types/map.cpp
+++ b/src/sass_types/map.cpp
@@ -1,7 +1,5 @@
 #include <nan.h>
-#include <sass_values.h>
 #include "map.h"
-#include "sass_value_wrapper.h"
 
 using namespace v8;
 

--- a/src/sass_types/map.h
+++ b/src/sass_types/map.h
@@ -2,14 +2,12 @@
 #define SASS_TYPES_MAP_H
 
 #include <nan.h>
-#include <sass_values.h>
 #include "sass_value_wrapper.h"
 
-
-namespace SassTypes 
+namespace SassTypes
 {
   using namespace v8;
-  
+
   class Map : public SassValueWrapper<Map> {
     public:
       Map(Sass_Value*);

--- a/src/sass_types/null.cpp
+++ b/src/sass_types/null.cpp
@@ -1,7 +1,5 @@
 #include <nan.h>
-#include <sass_values.h>
 #include "null.h"
-#include "sass_value_wrapper.h"
 
 using namespace v8;
 

--- a/src/sass_types/null.h
+++ b/src/sass_types/null.h
@@ -2,14 +2,12 @@
 #define SASS_TYPES_NULL_H
 
 #include <nan.h>
-#include <sass_values.h>
 #include "value.h"
 
-
-namespace SassTypes 
+namespace SassTypes
 {
   using namespace v8;
-  
+
   class Null : public Value {
     public:
       static Null& get_singleton();
@@ -29,6 +27,5 @@ namespace SassTypes
       static bool constructor_locked;
   };
 }
-
 
 #endif

--- a/src/sass_types/number.cpp
+++ b/src/sass_types/number.cpp
@@ -1,8 +1,6 @@
 #include <nan.h>
-#include <sass_values.h>
 #include "number.h"
 #include "../create_string.h"
-#include "sass_value_wrapper.h"
 
 using namespace v8;
 

--- a/src/sass_types/number.h
+++ b/src/sass_types/number.h
@@ -2,14 +2,12 @@
 #define SASS_TYPES_NUMBER_H
 
 #include <nan.h>
-#include <sass_values.h>
 #include "sass_value_wrapper.h"
 
-
-namespace SassTypes 
+namespace SassTypes
 {
   using namespace v8;
-  
+
   class Number : public SassValueWrapper<Number> {
     public:
       Number(Sass_Value*);

--- a/src/sass_types/sass_value_wrapper.h
+++ b/src/sass_types/sass_value_wrapper.h
@@ -4,11 +4,10 @@
 #include <stdexcept>
 #include <vector>
 #include <nan.h>
-#include <sass_values.h>
 #include "value.h"
 #include "factory.h"
 
-namespace SassTypes 
+namespace SassTypes
 {
   using namespace v8;
 
@@ -43,7 +42,7 @@ namespace SassTypes
 
   template <class T>
   SassValueWrapper<T>::SassValueWrapper(Sass_Value* v) {
-    this->value = sass_clone_value(v); 
+    this->value = sass_clone_value(v);
   }
 
   template <class T>
@@ -53,8 +52,8 @@ namespace SassTypes
   }
 
   template <class T>
-  Sass_Value* SassValueWrapper<T>::get_sass_value() { 
-    return sass_clone_value(this->value); 
+  Sass_Value* SassValueWrapper<T>::get_sass_value() {
+    return sass_clone_value(this->value);
   }
 
   template <class T>

--- a/src/sass_types/string.cpp
+++ b/src/sass_types/string.cpp
@@ -1,8 +1,6 @@
 #include <nan.h>
-#include <sass_values.h>
 #include "string.h"
 #include "../create_string.h"
-#include "sass_value_wrapper.h"
 
 using namespace v8;
 

--- a/src/sass_types/string.h
+++ b/src/sass_types/string.h
@@ -2,14 +2,12 @@
 #define SASS_TYPES_STRING_H
 
 #include <nan.h>
-#include <sass_values.h>
 #include "sass_value_wrapper.h"
 
-
-namespace SassTypes 
+namespace SassTypes
 {
   using namespace v8;
-  
+
   class String : public SassValueWrapper<String> {
     public:
       String(Sass_Value*);

--- a/src/sass_types/value.h
+++ b/src/sass_types/value.h
@@ -2,13 +2,12 @@
 #define SASS_TYPES_VALUE_H
 
 #include <nan.h>
-#include <sass_values.h>
+#include "../libsass/sass_values.h"
 
-
-namespace SassTypes 
+namespace SassTypes
 {
   using namespace v8;
-  
+
   // This is the interface that all sass values must comply with
   class Value {
     public:
@@ -16,6 +15,5 @@ namespace SassTypes
       virtual Local<Object> get_js_object() =0;
   };
 }
-
 
 #endif


### PR DESCRIPTION
Minor cleanup; removing redundant headers
from `.cpp` files.

Based on: https://github.com/sass/node-sass/pull/763#issuecomment-86293997.