### PR TITLE
Feature: Provides sourceMapRoot option

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,17 +222,23 @@ Default: `undefined`
 
 Enables the outputting of a source map during `render` and `renderSync`. When `sourceMap === true`, the value of `outFile` is used as the target output location for the source map. When `typeof sourceMap === "String"`, the value of `sourceMap` will be used as the writing location for the file.
 
+### sourceMapContents
+Type: `Boolean`
+Default: `false`
+
+`true` includes the `contents` in the source map information
+
 ### sourceMapEmbed
 Type: `Boolean`
 Default: `false`
 
 `true` embeds the source map as a data URI
 
-### sourceMapContents
-Type: `Boolean`
-Default: `false`
+### sourceMapRoot
+Type: `String`
+Default: `undefined`
 
-`true` includes the `contents` in the source map information
+the value will be emitted as `sourceRoot` in the source map information
 
 ## `render` Callback (>= v3.0.0)
 node-sass supports standard node style asynchronous callbacks with the signature of `function(err, result)`. In error conditions, the `error` argument is populated with the error object. In success conditions, the `result` object is populated with an object describing the result of the render call.
@@ -441,8 +447,9 @@ Output will be saved with the same name as input SASS file into the current work
     --linefeed                 Linefeed style (cr | crlf | lf | lfcr)
     --source-comments          Include debug info in output
     --source-map               Emit source map
-    --source-map-embed         Embed sourceMappingUrl as data URI
     --source-map-contents      Embed include contents in map
+    --source-map-embed         Embed sourceMappingUrl as data URI
+    --source-map-root          Base path, will be emitted in source-map as is
     --include-path             Path to look for imported files
     --precision                The amount of precision allowed in decimal numbers
     --importer                 Path to custom importer

--- a/bin/node-sass
+++ b/bin/node-sass
@@ -37,8 +37,9 @@ var cli = meow({
     '  --linefeed                 Linefeed style (cr | crlf | lf | lfcr)',
     '  --source-comments          Include debug info in output',
     '  --source-map               Emit source map',
-    '  --source-map-embed         Embed sourceMappingUrl as data URI',
     '  --source-map-contents      Embed include contents in map',
+    '  --source-map-embed         Embed sourceMappingUrl as data URI',
+    '  --source-map-root          Base path, will be emitted in source-map as is',
     '  --include-path             Path to look for imported files',
     '  --precision                The amount of precision allowed in decimal numbers',
     '  --importer                 Path to custom importer',
@@ -60,6 +61,7 @@ var cli = meow({
     'output',
     'output-style',
     'precision',
+    'source-map-root',
     'watch'
   ],
   alias: {

--- a/lib/render.js
+++ b/lib/render.js
@@ -28,6 +28,7 @@ module.exports = function(options, emitter) {
     sourceMapEmbed: options.sourceMapEmbed,
     sourceMapContents: options.sourceMapContents,
     sourceMap: options.sourceMap,
+    sourceMapRoot: options.sourceMapRoot,
     importer: options.importer,
     indentWidth: options.indentWidth,
     indentType: options.indentType,

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -90,6 +90,7 @@ void ExtractOptions(Local<Object> options, void* cptr, sass_context_wrapper* ctx
   ctx_w->include_path = create_string(options->Get(NanNew("includePaths")));
   ctx_w->out_file = create_string(options->Get(NanNew("outFile")));
   ctx_w->source_map = create_string(options->Get(NanNew("sourceMap")));
+  ctx_w->source_map_root = create_string(options->Get(NanNew("sourceMapRoot")));
 
   sass_option_set_output_path(sass_options, ctx_w->out_file);
   sass_option_set_output_style(sass_options, (Sass_Output_Style)options->Get(NanNew("style"))->Int32Value());
@@ -99,6 +100,7 @@ void ExtractOptions(Local<Object> options, void* cptr, sass_context_wrapper* ctx
   sass_option_set_source_map_embed(sass_options, options->Get(NanNew("sourceMapEmbed"))->BooleanValue());
   sass_option_set_source_map_contents(sass_options, options->Get(NanNew("sourceMapContents"))->BooleanValue());
   sass_option_set_source_map_file(sass_options, ctx_w->source_map);
+  sass_option_set_source_map_root(sass_options, ctx_w->source_map_root);
   sass_option_set_include_path(sass_options, ctx_w->include_path);
   sass_option_set_precision(sass_options, options->Get(NanNew("precision"))->Int32Value());
   sass_option_set_indent(sass_options, ctx_w->indent);

--- a/src/sass_context_wrapper.cpp
+++ b/src/sass_context_wrapper.cpp
@@ -43,6 +43,7 @@ extern "C" {
     free(ctx_w->linefeed);
     free(ctx_w->out_file);
     free(ctx_w->source_map);
+    free(ctx_w->source_map_root);
     free(ctx_w->indent);
 
     if (string) {

--- a/src/sass_context_wrapper.h
+++ b/src/sass_context_wrapper.h
@@ -27,6 +27,7 @@ extern "C" {
     char* include_path;
     char* out_file;
     char* source_map;
+    char* source_map_root;
     char* linefeed;
     char* indent;
 

--- a/test/api.js
+++ b/test/api.js
@@ -52,6 +52,18 @@ describe('api', function() {
       });
     });
 
+    it('should compile generate map with sourceMapRoot pass-through option', function(done) {
+      sass.render({
+        file: fixture('simple/index.scss'),
+        sourceMap: './deep/nested/index.map',
+        sourceMapRoot: 'http://test.com/',
+        outFile: './index-test.css'
+      }, function(error, result) {
+        assert.equal(JSON.parse(result.map).sourceRoot, 'http://test.com/');
+        done();
+      });
+    });
+
     it('should compile sass to css with data', function(done) {
       var src = read(fixture('simple/index.scss'), 'utf8');
       var expected = read(fixture('simple/expected.css'), 'utf8').trim();
@@ -976,6 +988,18 @@ describe('api', function() {
       });
 
       assert.equal(JSON.parse(result.map).file, '../../index-test.css');
+      done();
+    });
+
+    it('should compile generate map with sourceMapRoot pass-through option', function(done) {
+      var result = sass.renderSync({
+        file: fixture('simple/index.scss'),
+        sourceMap: './deep/nested/index.map',
+        sourceMapRoot: 'http://test.com/',
+        outFile: './index-test.css'
+      });
+
+      assert.equal(JSON.parse(result.map).sourceRoot, 'http://test.com/');
       done();
     });
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -256,6 +256,27 @@ describe('cli', function() {
         done();
       });
     });
+
+    it('should compile with the --source-root option', function(done) {
+      var src = fixture('source-map/index.scss');
+      var destCss = fixture('source-map/index.css');
+      var destMap = fixture('source-map/index.map');
+      var expectedCss = read(fixture('source-map/expected.css'), 'utf8').trim().replace(/\r\n/g, '\n');
+      var expectedUrl = 'http://test/';
+      var bin = spawn(cli, [
+        src, '--output', path.dirname(destCss),
+        '--source-map-root', expectedUrl,
+        '--source-map', destMap
+      ]);
+
+      bin.once('close', function() {
+        assert.equal(read(destCss, 'utf8').trim(), expectedCss);
+        assert.equal(JSON.parse(read(destMap, 'utf8')).sourceRoot, expectedUrl);
+        fs.unlinkSync(destCss);
+        fs.unlinkSync(destMap);
+        done();
+      });
+    });
   });
 
   describe('node-sass in.scss --output path/to/file/out.css', function() {


### PR DESCRIPTION
Related discussions: https://github.com/sass/node-sass/issues/731 & https://github.com/sass/libsass/issues/908.
//cc @itsnydell and @joliss

According to the [source-map v3 docs](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit?pli=1#):

> (sourceRoot is) An optional source root, useful for relocating source files on a server or removing repeated values in the “sources” entry.  This value is prepended to the individual entries in the “source” field.

Further it goes:

> **Resolving Sources**
If the sources are not absolute URLs after prepending of the “sourceRoot”, the sources are resolved relative to the SourceMap (like resolving script src in a html document).

Therefore, node-sass will pass the value of `sourceMapRoot` (or `source-map-root`) to the libsass as is, which will return it back in source map as `sourceRoot`, without affecting anything else.

See the usage example in written tests.

Issue URL: #776.