### PR TITLE
Fix #775: Introduce SASS_BINARY_SITE environment variable

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -50,7 +50,7 @@ function getRuntimeInfo() {
 /**
  * Get binary name.
  * If environment variable SASS_BINARY_NAME or
- * process aurgument --binary-name is provide,
+ * process argument --binary-name is provided,
  * return it as is, otherwise make default binary
  * name: {platform}-{arch}-{v8 version}.node
  *
@@ -62,10 +62,10 @@ function getBinaryName() {
 
   if (flags['--sass-binary-name']) {
     binaryName = flags['--sass-binary-name'];
-  } else if (package.nodeSassConfig && package.nodeSassConfig.binaryName) {
-    binaryName = package.nodeSassConfig.binaryName;
   } else if (process.env.SASS_BINARY_NAME) {
     binaryName = process.env.SASS_BINARY_NAME;
+  } else if (package.nodeSassConfig && package.nodeSassConfig.binaryName) {
+    binaryName = package.nodeSassConfig.binaryName;
   } else {
     binaryName = [process.platform, '-',
                   process.arch, '-',
@@ -76,21 +76,40 @@ function getBinaryName() {
 }
 
 /**
- * Retrieve the URL to fetch binary.
- * If environment variable SASS_BINARY_URL
- * is set, return that path. Otherwise make
- * path using current release version and
- * binary name.
+ * Determine the URL to fetch binary file from.
+ * By default feth from the node-sass distribution
+ * site on GitHub.
+ * 
+ * The default URL can be overriden using
+ * the environment variable SASS_BINARY_SITE
+ * or a command line option --sass-binary-site:
+ *
+ *   node scripts/install.js --sass-binary-site http://example.com/
+ *
+ * The URL should to the mirror of the repository
+ * laid out as follows:
+ *
+ * SASS_BINARY_SITE/
+ * 
+ *  v3.0.0-beta.4
+ *  v3.0.0-beta.4/freebsd-x64-14_binding.node
+ *  ....
+ *  v3.0.0-beta.5
+ *  v3.0.0-beta.5/freebsd-ia32-11_binding.node
+ *  v3.0.0-beta.5/freebsd-x64-42_binding.node
+ *  ... etc. for all supported versions and platforms
  *
  * @api private
  */
 
 function getBinaryUrl() {
-  return flags['--sass-binary-url'] ||
-         package.nodeSassConfig ? package.nodeSassConfig.binaryUrl : null ||
-         process.env.SASS_BINARY_URL ||
-         ['https://github.com/sass/node-sass/releases/download/v',
-          package.version, '/', sass.binaryName].join('');
+  var site = flags['--sass-binary-site'] || process.env.SASS_BINARY_SITE  ||
+             (package.nodeSassConfig ? package.nodeSassConfig.binarySite : null);
+  if (site) {
+		  return [site, 'v' + package.version, sass.binaryName].join('/');
+  } else {
+          return null;
+  }
 }
 
 /**
@@ -118,7 +137,7 @@ sass.versionInfo = getVersionInfo();
 /**
  * Get binary path.
  * If environment variable SASS_BINARY_PATH or
- * process aurgument --binary-path is provide,
+ * process argument --sass-binary-path is provided,
  * select it by appending binary name, otherwise
  * make default binary path using binary name.
  * Once the primary selection is made, check if
@@ -134,10 +153,10 @@ sass.getBinaryPath = function(throwIfNotExists) {
 
   if (flags['--sass-binary-path']) {
     binaryPath = flags['--sass-binary-path'];
-  } else if (package.nodeSassConfig && package.nodeSassConfig.binaryPath) {
-    binaryPath = package.nodeSassConfig.binaryPath;
   } else if (process.env.SASS_BINARY_PATH) {
     binaryPath = process.env.SASS_BINARY_PATH;
+  } else if (package.nodeSassConfig && package.nodeSassConfig.binaryPath) {
+    binaryPath = package.nodeSassConfig.binaryPath;
   } else {
     binaryPath = path.join(__dirname, '..', 'vendor', sass.binaryName.replace(/_/, '/'));
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "node": ">=0.10.0"
   },
   "main": "lib/index.js",
+  "nodeSassConfig": {
+    "binarySite1": "https://github.com/sass/node-sass/releases/download"
+  },
   "bin": {
     "node-sass": "bin/node-sass"
   },


### PR DESCRIPTION
Provide ability to locally mirror node-sass
binaries for various versions and platforms.

SASS_DIST_SITE needs to be an URL pointing to
a collection of files organized like the Github
repository.

If SASS_DIST_SITE is set to

 http://myhost:8080/local/node-sass-bin

then

 http://myhost:8080/local/node-sass-bin/v3.0.0-beta.4/freebsd-x64-14_binding.node

should point to the FreeBSD 64 bit binary for node 0.12.0