### PR TITLE
Code: Don't throw from interim callback state

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -122,10 +122,6 @@ void ExtractOptions(Local<Object> options, void* cptr, sass_context_wrapper* ctx
     for (size_t i = 0; i < importers->Length(); ++i) {
       Local<Function> callback = Local<Function>::Cast(importers->Get(static_cast<uint32_t>(i)));
 
-      if (!callback->IsFunction()) {
-        NanThrowError(NanNew("options.importer must be set to a function or array of functions"));
-      }
-
       auto bridge = std::make_shared<CustomImporterBridge>(new NanCallback(callback), ctx_w->is_sync);
       ctx_w->importer_bridges.push_back(bridge);
 
@@ -146,10 +142,6 @@ void ExtractOptions(Local<Object> options, void* cptr, sass_context_wrapper* ctx
     for (unsigned i = 0; i < num_signatures; i++) {
       Local<String> signature = Local<String>::Cast(signatures->Get(NanNew(i)));
       Local<Function> callback = Local<Function>::Cast(functions->Get(signature));
-
-      if (!signature->IsString() || !callback->IsFunction()) {
-        NanThrowError(NanNew("options.functions must be a (signature -> function) hash"));
-      }
 
       auto bridge = std::make_shared<CustomFunctionBridge>(new NanCallback(callback), ctx_w->is_sync);
       ctx_w->function_bridges.push_back(bridge);

--- a/src/custom_importer_bridge.cpp
+++ b/src/custom_importer_bridge.cpp
@@ -17,7 +17,9 @@ SassImportList CustomImporterBridge::post_process_return_value(Handle<Value> val
       Local<Value> value = array->Get(static_cast<uint32_t>(i));
 
       if (!value->IsObject()) {
-        NanThrowError(NanNew("returned array must only contain object literals"));
+        auto entry = sass_make_import_entry(0, 0, 0);
+        sass_import_set_error(entry, "returned array must only contain object literals", -1, -1);
+        continue;
       }
 
       Local<Object> object = Local<Object>::Cast(value);


### PR DESCRIPTION
Lets the error propagate to libsass.

This goes against the concept of fast aborting,
but this way downstream user will not get a blunt
exception, but receive a well-formatted JSON
error.

Note: this exception from importer callback's
post-process handler cannot be captured by try-
catch.

The edit in binding.cpp is also required, because
those conditions will never get satisfied anyway.
Removed due to aforementioned reasons.