### PR TITLE
CLI: Adds support for multi-file compilation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,9 @@ Output will be saved with the same name as input SASS file into the current work
     --help                     Print usage info
 ```
 
-Note `--importer` takes the (absolute or relative to pwd) path to a js file, which needs to have a default `module.exports` set to the importer function. See our test [fixtures](https://github.com/sass/node-sass/tree/974f93e76ddd08ea850e3e663cfe64bb6a059dd3/test/fixtures/extras) for example.
+Pass a directory as the input to compile multiple files. For example: `node-sass sass/ -o css/`. The `--output` flag is required and must be a directory when using multi-file compilation.
+
+Also, note `--importer` takes the (absolute or relative to pwd) path to a js file, which needs to have a default `module.exports` set to the importer function. See our test [fixtures](https://github.com/sass/node-sass/tree/974f93e76ddd08ea850e3e663cfe64bb6a059dd3/test/fixtures/extras) for example.
 
 ## Post-install Build
 

--- a/bin/node-sass
+++ b/bin/node-sass
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
 
 var Emitter = require('events').EventEmitter,
+    forEach = require('async-foreach').forEach,
     Gaze = require('gaze'),
     grapher = require('sass-graph'),
     meow = require('meow'),
+    util = require('util'),
     path = require('path'),
+    glob = require('glob'),
     render = require('../lib/render'),
-    stdin = require('get-stdin');
+    stdin = require('get-stdin'),
+    fs = require('fs');
 
 /**
  * Initialize CLI
@@ -88,14 +92,34 @@ var cli = meow({
 });
 
 /**
- * Check if file is a Sass file
+ * Is a Directory
  *
- * @param {String} file
+ * @param {String} filePath
+ * @returns {Boolean}
  * @api private
  */
 
-function isSassFile(file) {
-  return file.match(/\.(sass|scss)/);
+function isDirectory(filePath) {
+  var isDir = false;
+  try {
+    var absolutePath = path.resolve(process.cwd(), filePath);
+    isDir = fs.lstatSync(absolutePath).isDirectory();
+  } catch (e) {
+    isDir = e.code === 'ENOENT';
+  }
+  return isDir;
+}
+
+/**
+ * Get correct glob pattern
+ *
+ * @param {Object} options
+ * @returns {String}
+ * @api private
+ */
+
+function globPattern(options) {
+  return options.recursive ? '**/*.{sass,scss}' : '*.{sass,scss}';
 }
 
 /**
@@ -123,7 +147,7 @@ function getEmitter() {
   });
 
   emitter.on('done', function() {
-    if (!options.watch) {
+    if (!options.watch && !options.directory) {
       process.exit;
     }
   });
@@ -150,6 +174,13 @@ function getOptions(args, options) {
       [path.basename(options.src, path.extname(options.src)), '.css'].join(''));  // replace ext.
   }
 
+  if (options.directory) {
+    var sassDir = path.resolve(process.cwd(), options.directory);
+    var file = path.relative(sassDir, args[0]);
+    var cssDir = path.resolve(process.cwd(), options.output);
+    options.dest = path.join(cssDir, file).replace(path.extname(file), '.css');
+  }
+
   return options;
 }
 
@@ -162,8 +193,7 @@ function getOptions(args, options) {
  */
 
 function watch(options, emitter) {
-  var glob = options.recursive ? '**/*.{sass,scss}' : '*.{sass,scss}';
-  var src = isSassFile(options.src) ? options.src : path.join(options.src, glob);
+  var src = options.directory ? path.join(options.directory, globPattern(options)) : options.src;
   var graph = grapher.parseDir(path.resolve(path.dirname(src)), { loadPaths: options.includePath });
   var watch = [];
 
@@ -181,12 +211,10 @@ function watch(options, emitter) {
     graph.visitAncestors(file, function(parent) {
       files.push(parent);
     });
-
     files.forEach(function(file) {
-      if (path.basename(file)[0] === '_') return;
-      options = getOptions([path.resolve(file)], options);
-      emitter.emit('warn', '=> changed: ' + file);
-      render(options, emitter);
+      if (path.basename(file)[0] !== '_') {
+        renderFile(file, options, emitter);
+      }
     });
   });
 }
@@ -202,6 +230,15 @@ function watch(options, emitter) {
 function run(options, emitter) {
   if (!Array.isArray(options.includePath)) {
     options.includePath = [options.includePath];
+  }
+
+  if (options.directory) {
+    if (!options.output) {
+      emitter.emit('error', 'Specify an output directory when using multi-file compilation');
+    }
+    if (!isDirectory(options.output)) {
+      emitter.emit('error', util.format('Multi-file compilation: requires destination %s to be a directory.', options.output));
+    }
   }
 
   if (options.sourceMap) {
@@ -235,9 +272,53 @@ function run(options, emitter) {
 
   if (options.watch) {
     watch(options, emitter);
+  } else if (options.directory) {
+    renderDir(options, emitter);
   } else {
     render(options, emitter);
   }
+}
+
+/**
+ * Render a file
+ *
+ * @param {String} file
+ * @param {Object} options
+ * @param {Object} emitter
+ * @api private
+ */
+function renderFile(file, options, emitter) {
+  options = getOptions([path.resolve(file)], options);
+  if (options.watch) {
+    emitter.emit('warn', util.format('=> changed: %s', file));
+  }
+  render(options, emitter);
+}
+
+/**
+ * Render all sass files in a directory
+ *
+ * @param {Object} options
+ * @param {Object} emitter
+ * @api private
+ */
+function renderDir(options, emitter) {
+  var globPath = path.resolve(process.cwd(), options.directory, globPattern(options));
+  glob(globPath, {ignore: '**/_*'}, function(err, files) {
+    if(err) {
+      return emitter.emit('error', util.format('You do not have permission to access this path: %s.', err.path));
+    } else if(!files.length) {
+      return emitter.emit('error', 'No input file was found.');
+    }
+    forEach(files, function(subject) {
+      emitter.once('done', this.async());
+      renderFile(subject, options, emitter);
+    }, function(successful, arr) {
+      var outputDir = path.join(process.cwd(), options.output);
+      emitter.emit('warn', util.format('Wrote %s CSS files to %s', arr.lenth, outputDir));
+      process.exit;
+    });
+  });
 }
 
 /**
@@ -266,6 +347,9 @@ if (!options.src && process.stdin.isTTY) {
  */
 
 if (options.src) {
+  if (isDirectory(options.src)){
+    options.directory = options.src;
+  }
   run(options, emitter);
 } else if (!process.stdin.isTTY) {
   stdin(function(data) {

--- a/package.json
+++ b/package.json
@@ -45,9 +45,11 @@
     "style"
   ],
   "dependencies": {
+    "async-foreach": "^0.1.3",
     "chalk": "^1.0.0",
     "gaze": "^0.5.1",
     "get-stdin": "^4.0.1",
+    "glob": "^5.0.3",
     "meow": "^3.1.0",
     "mkdirp": "^0.5.0",
     "nan": "^1.7.0",
@@ -62,6 +64,7 @@
     "jscoverage": "^0.5.9",
     "jshint": "^2.6.3",
     "mocha": "^2.2.1",
-    "mocha-lcov-reporter": "^0.0.2"
+    "mocha-lcov-reporter": "^0.0.2",
+    "rimraf": "^2.3.2"
   }
 }

--- a/test/fixtures/input-directory/sass/_skipped.scss
+++ b/test/fixtures/input-directory/sass/_skipped.scss
@@ -1,0 +1,16 @@
+#navbar {
+  width: 80%;
+  height: 23px;
+}
+
+#navbar ul {
+  list-style-type: none;
+}
+
+#navbar li {
+  float: left;
+
+  a {
+    font-weight: bold;
+  }
+}

--- a/test/fixtures/input-directory/sass/nested/three.scss
+++ b/test/fixtures/input-directory/sass/nested/three.scss
@@ -1,0 +1,16 @@
+#navbar {
+  width: 80%;
+  height: 23px;
+}
+
+#navbar ul {
+  list-style-type: none;
+}
+
+#navbar li {
+  float: left;
+
+  a {
+    font-weight: bold;
+  }
+}

--- a/test/fixtures/input-directory/sass/one.scss
+++ b/test/fixtures/input-directory/sass/one.scss
@@ -1,0 +1,16 @@
+#navbar {
+  width: 80%;
+  height: 23px;
+}
+
+#navbar ul {
+  list-style-type: none;
+}
+
+#navbar li {
+  float: left;
+
+  a {
+    font-weight: bold;
+  }
+}

--- a/test/fixtures/input-directory/sass/two.scss
+++ b/test/fixtures/input-directory/sass/two.scss
@@ -1,0 +1,16 @@
+#navbar {
+  width: 80%;
+  height: 23px;
+}
+
+#navbar ul {
+  list-style-type: none;
+}
+
+#navbar li {
+  float: left;
+
+  a {
+    font-weight: bold;
+  }
+}


### PR DESCRIPTION
As per #828 - Adds the ability to compile multiple files from a directory.

Given this structure:

```
- sass/
| - main.scss
|  | - components/
|  |  | - _component1.scss
|  | - pages/
|  |  | - page1.scss
|  |  | - page2.scss
```

If you run: `node-sass sass/ -o build/`, you would get this output:

```
- sass/
- build/
| - main.css
|  | - pages/
|  |  | - page1.css
|  |  | - page2.css
```

Skips files that start with an `_`. Also respects the current `--recursive` flag. So given the same structure as above, if you ran `node-sass sass/ -o build/ --recursive false`, you would get:

```
- sass/
- build/
| - main.css
```

- Throws an error if you don't difine `--output`
- Throws an error if `--output` isn't a directory
- If `--output` is defined, but the folder doesn't exist, it will create it.



Very much looking for feedback. Things that feel specifically weird:

1. The fact that `done` is declared as a variable in the root scope of the file. (feels hacky)
2. The fact that this is waiting for each file to be finished before compiling the next one. (could probably be done in parallel?)
