### PR TITLE
Code: Skips path.resolve when outFile is not set

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@ function getSourceMap(options) {
     sourceMap = options.outFile + '.map';
   }
 
-  return sourceMap ? path.resolve(sourceMap) : null;
+  return sourceMap && typeof sourceMap === 'string' ? path.resolve(sourceMap) : null;
 }
 
 /**


### PR DESCRIPTION
This was reported at https://github.com/sindresorhus/grunt-sass/issues/203. It is an edge case, if user is already using `outFile` option with `sourceMap: true`, the exception will not be thrown.