### PR TITLE
CLI: switch successful message event type

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -138,10 +138,6 @@ function getEmitter() {
     }
   });
 
-  emitter.on('warn', function(data) {
-    console.warn(data);
-  });
-
   emitter.on('log', function(data) {
     console.log(data);
   });
@@ -290,7 +286,7 @@ function run(options, emitter) {
 function renderFile(file, options, emitter) {
   options = getOptions([path.resolve(file)], options);
   if (options.watch) {
-    emitter.emit('warn', util.format('=> changed: %s', file));
+    emitter.emit('log', util.format('=> changed: %s', file));
   }
   render(options, emitter);
 }
@@ -315,7 +311,7 @@ function renderDir(options, emitter) {
       renderFile(subject, options, emitter);
     }, function(successful, arr) {
       var outputDir = path.join(process.cwd(), options.output);
-      emitter.emit('warn', util.format('Wrote %s CSS files to %s', arr.lenth, outputDir));
+      emitter.emit('log', util.format('Wrote %s CSS files to %s', arr.lenth, outputDir));
       process.exit;
     });
   });

--- a/lib/render.js
+++ b/lib/render.js
@@ -60,7 +60,7 @@ module.exports = function(options, emitter) {
       return done();
     }
 
-    emitter.emit('warn', chalk.green('Rendering Complete, saving .css file...'));
+    emitter.emit('log', chalk.green('Rendering Complete, saving .css file...'));
 
     mkdirp(path.dirname(options.dest), function(err) {
       if (err) {
@@ -72,7 +72,7 @@ module.exports = function(options, emitter) {
           return emitter.emit('error', chalk.red(err));
         }
 
-        emitter.emit('warn', chalk.green('Wrote CSS to ' + options.dest));
+        emitter.emit('log', chalk.green('Wrote CSS to ' + options.dest));
         emitter.emit('write', err, options.dest, result.css.toString());
         done();
       });
@@ -86,7 +86,7 @@ module.exports = function(options, emitter) {
           return emitter.emit('error', chalk.red('Error' + err));
         }
 
-        emitter.emit('warn', chalk.green('Wrote Source Map to ' + options.sourceMap));
+        emitter.emit('log', chalk.green('Wrote Source Map to ' + options.sourceMap));
         emitter.emit('write-source-map', err, options.sourceMap, result.map);
         done();
       });

--- a/test/cli.js
+++ b/test/cli.js
@@ -169,15 +169,15 @@ describe('cli', function() {
       }, 100);
     });
 
-    it('should emit `warn` on file change when using --watch option', function(done) {
+    it('should emit `log` on file change when using --watch option', function(done) {
       var src = fixture('simple/tmp.scss');
 
       fs.writeFileSync(src, '');
 
       var bin = spawn(cli, ['--watch', src]);
 
-      bin.stderr.setEncoding('utf8');
-      bin.stderr.once('data', function(data) {
+      bin.stdout.setEncoding('utf8');
+      bin.stdout.once('data', function(data) {
         assert(data.trim() === '=> changed: ' + src);
         fs.unlinkSync(src);
         done();
@@ -200,7 +200,7 @@ describe('cli', function() {
 
       bin.stdout.setEncoding('utf8');
       bin.stdout.once('data', function(data) {
-        assert(data.trim() === 'body{background:white}');
+        assert(data.trim() === '=> changed: ' + src);
         fs.unlinkSync(src);
         done();
       });
@@ -223,7 +223,7 @@ describe('cli', function() {
 
       bin.stdout.setEncoding('utf8');
       bin.stdout.once('data', function(data) {
-        assert(data.trim() === 'body{background:white}');
+        assert(data.trim() === '=> changed: ' + foo);
         done();
       });
 


### PR DESCRIPTION
hey guys. this pull request is meant to solve a simple issue:
send CLI succesful messages to stdout instead of stderr.

currently redirecting the stdout has no effect:

```shell
node-sass input.scss output.css > /dev/null
```

the above command still outputs:

```
Rendering Complete, saving .css file...
Wrote CSS to path/to/output.css
```

I could redirect the stderr, but then it would be impossible to know if something breaks.

what do you guys think?