### PR TITLE
CLI: Adds --quiet flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ Output will be saved with the same name as input SASS file into the current work
     -o, --output               Output directory
     -x, --omit-source-map-url  Omit source map URL comment from output
     -i, --indented-syntax      Treat data from stdin as sass code (versus scss)
+    -q, --quiet                Suppress log output except on error
     -v, --version              Prints version info
     --output-style             CSS output style (nested | expanded | compact | compressed)
     --indent-type              Indent type for output CSS (space | tab)

--- a/bin/node-sass
+++ b/bin/node-sass
@@ -34,6 +34,7 @@ var cli = meow({
     '  -o, --output               Output directory',
     '  -x, --omit-source-map-url  Omit source map URL comment from output',
     '  -i, --indented-syntax      Treat data from stdin as sass code (versus scss)',
+    '  -q, --quiet                Suppress log output except on error',
     '  -v, --version              Prints version info',
     '  --output-style             CSS output style (nested | expanded | compact | compressed)',
     '  --indent-type              Indent type for output CSS (space | tab)',
@@ -54,6 +55,7 @@ var cli = meow({
   boolean: [
     'indented-syntax',
     'omit-source-map-url',
+    'quiet',
     'recursive',
     'source-map-embed',
     'source-map-contents',
@@ -74,6 +76,7 @@ var cli = meow({
   alias: {
     c: 'source-comments',
     i: 'indented-syntax',
+    q: 'quiet',
     o: 'output',
     r: 'recursive',
     x: 'omit-source-map-url',
@@ -87,6 +90,7 @@ var cli = meow({
     linefeed: 'lf',
     'output-style': 'nested',
     precision: 5,
+    quiet: false,
     recursive: true
   }
 });
@@ -139,7 +143,9 @@ function getEmitter() {
   });
 
   emitter.on('warn', function(data) {
-    console.warn(data);
+    if (!options.quiet) {
+      console.warn(data);
+    }
   });
 
   emitter.on('log', function(data) {

--- a/test/fixtures/invalid/index.scss
+++ b/test/fixtures/invalid/index.scss
@@ -1,0 +1,3 @@
+body {
+  background-color: $green;
+}


### PR DESCRIPTION
Don't want to step on toes here if you were already working on this, @gibatronic , but thought I'd take a stab at implementing the `-q, --quiet` flag for the cli. 

I think this addresses the use case of #841 

Wrote some tests to ensure that the flag keeps the cli from outputting to `stderr` on `log` and `warn`. Also wrote a test to ensure that `error` is still passed through, regardless of if `--quiet` is used by creating an `invalid` fixture which contains a reference to an undefined sass variable. 

@gibatronic would this successfully enable you to do what you need to do?
/cc @am11 @wesleytodd 