### PR TITLE
Check libSass submodule when npm installing via git url

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -3,6 +3,7 @@
  */
 
 var eol = require('os').EOL,
+    pkg = require('../package.json'),
     fs = require('fs'),
     mkdir = require('mkdirp'),
     path = require('path'),
@@ -46,6 +47,49 @@ function afterBuild(options) {
 }
 
 /**
+ * initSubmodules
+ *
+ * @param {Function} cb
+ * @api private
+ */
+
+function initSubmodules(cb) {
+  var errorMsg = '';
+  var git = spawn(['LIBSASS_GIT_VERSION=', pkg.libsass, ' ./scripts/git.sh'].join());
+  git.stderr.on('data', function(data) {
+    errorMsg += data.toString();
+  });
+  git.on('close', function(code) {
+    var error;
+    if (code !== 0) {
+      error = { message: errorMsg + 'Unable to checkout the libSass submodule' };
+    }
+    cb(error);
+  });
+}
+
+/**
+ * installGitDependencies
+ *
+ * @param {Function} cb
+ * @api private
+ */
+
+function installGitDependencies(cb) {
+  var libsassPath = './src/libsass';
+
+  if (fs.access) { // node 0.12+, iojs 1.0.0+
+    fs.access(libsassPath, fs.R_OK, function(err) {
+      err && err.code === 'ENOENT' ? initSubmodules(cb) : cb();
+    });
+  } else { // node < 0.12
+    fs.exists(libsassPath, function(exists) {
+      exists ? cb() : initSubmodules(cb);
+    });
+  }
+}
+
+/**
  * Build
  *
  * @param {Object} options
@@ -53,25 +97,33 @@ function afterBuild(options) {
  */
 
 function build(options) {
-  var args = [path.join('node_modules', 'pangyp', 'bin', 'node-gyp'), 'rebuild'].concat(
-    ['libsass_ext', 'libsass_cflags', 'libsass_ldflags', 'libsass_library'].map(function(subject) {
-      return ['--', subject, '=', process.env[subject.toUpperCase()] || ''].join('');
-    })).concat(options.args);
-
-  console.log(['Building:', process.sass.runtime.execPath].concat(args).join(' '));
-
-  var proc = spawn(process.sass.runtime.execPath, args, {
-    stdio: [0, 1, 2]
-  });
-
-  proc.on('exit', function(errorCode) {
-    if (!errorCode) {
-      afterBuild(options);
-
-      return;
+  installGitDependencies(function(err) {
+    if (err) {
+      console.error(err.message);
+      process.exit(1);
     }
 
-    console.error(errorCode === 127 ? 'node-gyp not found!' : 'Build failed');
+    var args = [path.join('node_modules', 'pangyp', 'bin', 'node-gyp'), 'rebuild'].concat(
+      ['libsass_ext', 'libsass_cflags', 'libsass_ldflags', 'libsass_library'].map(function(subject) {
+        return ['--', subject, '=', process.env[subject.toUpperCase()] || ''].join('');
+      })).concat(options.args);
+
+    console.log(['Building:', process.sass.runtime.execPath].concat(args).join(' '));
+
+    var proc = spawn(process.sass.runtime.execPath, args, {
+      stdio: [0, 1, 2]
+    });
+
+    proc.on('exit', function(errorCode) {
+      if (!errorCode) {
+        afterBuild(options);
+
+        return;
+      }
+
+      console.error(errorCode === 127 ? 'node-gyp not found!' : 'Build failed');
+      process.exit(1);
+    });
   });
 }
 

--- a/scripts/git.sh
+++ b/scripts/git.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+git clone --depth=1 git@github.com:sass/libsass.git ./src/libsass
+cd ./src/libsass
+git checkout $LIBSASS_GIT_VERSION


### PR DESCRIPTION
This PR fixes npm installs via git urls erring when building the bindings.

When developing on node-sass I often npm install dev branches into my production code to test for regression or other issues. At the moment this require checking in the `src/libsass` directory, then rebasing that commit out when creating a PR.

This PR makes it so the libsass submodule is checked out as part of the postinstall process. The version checked out denoted by the existing `package.libsass` flag.

/cc @am11