### PR TITLE
Fix bug with join defaulting to comma separator

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -55,7 +55,7 @@ function afterBuild(options) {
 
 function initSubmodules(cb) {
   var errorMsg = '';
-  var git = spawn(['LIBSASS_GIT_VERSION=', pkg.libsass, ' ./scripts/git.sh'].join());
+  var git = spawn(['LIBSASS_GIT_VERSION=', pkg.libsass, ' ./scripts/git.sh'].join(''));
   git.stderr.on('data', function(data) {
     errorMsg += data.toString();
   });


### PR DESCRIPTION
This PR fixes an issue with the build script's git submodule init. Originally reported https://github.com/sass/node-sass/pull/874#issuecomment-94421659.