### PR TITLE
Handle build script git operations in JS

### DIFF
--- a/scripts/git.sh
+++ b/scripts/git.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-git clone --depth=1 git@github.com:sass/libsass.git ./src/libsass
-cd ./src/libsass
-git checkout $LIBSASS_GIT_VERSION


### PR DESCRIPTION
This PR is an iteration in the build script's git fallback introduced in #874.

We're now executing the git operations purely from JS - no more shell script - because we <3 Windows.