### PR TITLE
Kill watcher processes during test

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -233,6 +233,7 @@ describe('cli', function() {
       bin.stderr.once('data', function(data) {
         assert(data.trim() === '=> changed: ' + src);
         fs.unlinkSync(src);
+        bin.kill();
         done();
       });
 
@@ -257,6 +258,7 @@ describe('cli', function() {
         fs.appendFileSync(src, 'body {}');
         setTimeout(function() {
           assert.equal(didEmit, false);
+          bin.kill();
           done();
           fs.unlinkSync(src);
         }, 200);
@@ -277,6 +279,7 @@ describe('cli', function() {
       bin.stdout.once('data', function(data) {
         assert(data.trim() === 'body{background:white}');
         fs.unlinkSync(src);
+        bin.kill();
         done();
       });
 
@@ -299,6 +302,7 @@ describe('cli', function() {
       bin.stdout.setEncoding('utf8');
       bin.stdout.once('data', function(data) {
         assert(data.trim() === 'body{background:white}');
+        bin.kill();
         done();
       });
 


### PR DESCRIPTION
After running npm test four node processes
keep on running:

85880  1  S        0:00,41 node node-sass/bin/node-sass --watch node-sass/test/fixtures/simple/tmp.scss
85883  1  S        0:00,41 node node-sass/bin/node-sass --watch --quiet node-sass/test/fixtures/simple/tmp.scss
85885  1  S        0:00,40 node node-sass/bin/node-sass --output-style compressed --watch node-sass/test/fixtures/simple/bar.scss
85888  1  S        0:00,42 node node-sass/bin/node-sass --output-style compressed --watch node-sass/test/fixtures/watching/index.scss

We need to explicitly kill them when the test is done.