### PR TITLE
Fix #912: Use runtime libsass version

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ console.log(result.stats);
 
 ### Version information (>= v2.0.0)
 
-Both `node-sass` and `libsass` version info is now present in `package.json` and is exposed via `info` method:
+Both `node-sass` and `libsass` version info is now exposed via the `info` method:
 
 ```javascript
 var sass = require('node-sass');
@@ -368,6 +368,8 @@ console.log(sass.info);
   libsass         3.1.0   (Sass Compiler) [C/C++]
 */
 ```
+
+Since node-sass >=v3.0.0 libsass version is determined at run time.
 
 ## Integrations
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -22,7 +22,7 @@
         '<!(node -e "require(\'nan\')")',
       ],
       'conditions': [
-        ['libsass_ext == ""', {
+        ['libsass_ext == "" or libsass_ext == "no"', {
           'dependencies': [
             'src/libsass.gyp:libsass',
           ]

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -2,8 +2,7 @@
  * node-sass: lib/extensions.js
  */
 
-var eol = require('os').EOL,
-    flags = {},
+var flags = {},
     fs = require('fs'),
     package = require('../package.json'),
     path = require('path');
@@ -109,18 +108,6 @@ function getBinaryUrl() {
 	return [site, 'v' + package.version, sass.binaryName].join('/');
 }
 
-/**
- * Get Sass version information
- *
- * @api private
- */
-
-function getVersionInfo() {
-  return [
-           ['node-sass', package.version, '(Wrapper)', '[JavaScript]'].join('\t'),
-           ['libsass  ', package.libsass, '(Sass Compiler)', '[C/C++]'].join('\t'),
-  ].join(eol);
-}
 
 collectArguments(process.argv.slice(2));
 
@@ -129,7 +116,6 @@ var sass = process.sass = {};
 sass.binaryName = getBinaryName();
 sass.binaryUrl = getBinaryUrl();
 sass.runtime = getRuntimeInfo();
-sass.versionInfo = getVersionInfo();
 
 /**
  * Get binary path.

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,8 +2,10 @@
  * node-sass: lib/index.js
  */
 
-var path = require('path'),
-    util = require('util');
+var eol = require('os').EOL,
+    path = require('path'),
+    util = require('util'),
+    package = require('../package.json');
 
 require('./extensions');
 
@@ -12,6 +14,19 @@ require('./extensions');
  */
 
 var binding = require(process.sass.getBinaryPath(true));
+
+/**
+ * Get Sass version information
+ *
+ * @api private
+ */
+
+function getVersionInfo(binding) {
+  return [
+           ['node-sass', package.version, '(Wrapper)', '[JavaScript]'].join('\t'),
+           ['libsass  ', binding.libsassVersion(), '(Sass Compiler)', '[C/C++]'].join('\t'),
+  ].join(eol);
+}
 
 /**
  * Get input file
@@ -400,6 +415,7 @@ module.exports.renderSync = function(options) {
  * @api public
  */
 
+process.sass.versionInfo = getVersionInfo(binding);
 module.exports.info = process.sass.versionInfo;
 
 /**

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -302,11 +302,17 @@ NAN_METHOD(render_file_sync) {
   NanReturnValue(NanNew<Boolean>(result == 0));
 }
 
+NAN_METHOD(libsass_version) {
+  NanScope();
+  NanReturnValue(NanNew<String>(libsass_version()));
+}
+
 void RegisterModule(v8::Handle<v8::Object> target) {
   NODE_SET_METHOD(target, "render", render);
   NODE_SET_METHOD(target, "renderSync", render_sync);
   NODE_SET_METHOD(target, "renderFile", render_file);
   NODE_SET_METHOD(target, "renderFileSync", render_file_sync);
+  NODE_SET_METHOD(target, "libsassVersion", libsass_version);
   SassTypes::Factory::initExports(target);
 }
 

--- a/src/libsass.gyp
+++ b/src/libsass.gyp
@@ -3,6 +3,9 @@
     {
       'target_name': 'libsass',
       'type': 'static_library',
+      'defines': [
+         'LIBSASS_VERSION="<!(node -e "process.stdout.write(require(\'../package.json\').libsass)")"'
+      ],
       'sources': [
         'libsass/ast.cpp',
         'libsass/base64vlq.cpp',
@@ -52,7 +55,7 @@
       ],
       'cflags_cc': [
         '-fexceptions',
-        '-frtti'
+        '-frtti',
       ],
       'direct_dependent_settings': {
         'include_dirs': [ 'libsass' ],

--- a/test/api.js
+++ b/test/api.js
@@ -1410,7 +1410,7 @@ describe('api', function() {
       assert(info.indexOf(package.version) > 0);
       assert(info.indexOf('(Wrapper)') > 0);
       assert(info.indexOf('[JavaScript]') > 0);
-      assert(info.indexOf(package.libsass) > 0);
+      assert(info.indexOf('[NA]') < 0);
       assert(info.indexOf('(Sass Compiler)') > 0);
       assert(info.indexOf('[C/C++]') > 0);
 


### PR DESCRIPTION
Return real libsass version
information - in when a shared library
is used this version may be changed
even without recompilation

libsass version in the package.json
file is now used only for checking
out the bundled libsass library
from the git submodule

PR: #912 