### PR TITLE
Watcher should prioritize cwd when resolving imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "npmconf": "^2.1.1",
     "pangyp": "^2.1.0",
     "request": "^2.55.0",
-    "sass-graph": "^1.2.0"
+    "sass-graph": "^2.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",


### PR DESCRIPTION
Currently when traversing the import graph we do not respect the behaviour of checking the current working directory first. This can result in the wrong files being compiled if there are naming collisions.

This was fixed upstream in sass-graph@2.0.0

Fixes #905.