### PR TITLE
build: Adds win_delay_hook so iojs runs with alias

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,6 +2,7 @@
   'targets': [
     {
       'target_name': 'binding',
+      'win_delay_load_hook': 'true',
       'sources': [
         'src/binding.cpp',
         'src/create_string.cpp',

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mkdirp": "^0.5.0",
     "nan": "^1.8.4",
     "npmconf": "^2.1.1",
-    "pangyp": "^2.1.0",
+    "pangyp": "am11/pangyp",
     "request": "^2.55.0",
     "sass-graph": "^2.0.0"
   },


### PR DESCRIPTION
Before building, first apply the following patch
to pangyp: rvagg/pangyp#5 (until it is merged).

Issue URL: #870.