### PR TITLE
--help fix: mentioning options also in stdin/stdout syntax

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -22,7 +22,7 @@ var cli = meow({
   help: [
     'Usage',
     '  node-sass [options] <input.scss> [output.css]',
-    '  cat <input.scss> | node-sass > output.css',
+    '  cat <input.scss> | node-sass [options] > output.css',
     '',
     'Example',
     '  node-sass --output-style compressed foobar.scss foobar.css',


### PR DESCRIPTION
When doing `node_modules/.bin/node-sass --help`, the "Usage" text didn't mention options in the stdin/stdout syntax, but they are there. The example uses them.

This adds a mention of options to the help text.