### PR TITLE
Ensure am11/pangyp not fetched via SSH

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mkdirp": "^0.5.0",
     "nan": "^1.8.4",
     "npmconf": "^2.1.1",
-    "pangyp": "am11/pangyp",
+    "pangyp": "https://github.com/am11/pangyp.git#f13599f5198b853948429062c2b334010a337342",
     "request": "^2.55.0",
     "sass-graph": "^2.0.0"
   },


### PR DESCRIPTION
Pin am11/pangyp to the particular commit

Should fix the problem mentioned in:
https://github.com/sass/node-sass/commit/579baf322ca48f73b04a009b70220a6c0a3cbc15#commitcomment-11082041