### PR TITLE
Remove use of 'package' as a variable name in install.js

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -4,7 +4,7 @@
 
 var flags = {},
     fs = require('fs'),
-    package = require('../package.json'),
+    pkg = require('../package.json'),
     path = require('path');
 
 /**
@@ -63,8 +63,8 @@ function getBinaryName() {
     binaryName = flags['--sass-binary-name'];
   } else if (process.env.SASS_BINARY_NAME) {
     binaryName = process.env.SASS_BINARY_NAME;
-  } else if (package.nodeSassConfig && package.nodeSassConfig.binaryName) {
-    binaryName = package.nodeSassConfig.binaryName;
+  } else if (pkg.nodeSassConfig && pkg.nodeSassConfig.binaryName) {
+    binaryName = pkg.nodeSassConfig.binaryName;
   } else {
     binaryName = [process.platform, '-',
                   process.arch, '-',
@@ -104,8 +104,8 @@ function getBinaryName() {
 function getBinaryUrl() {
   var site = flags['--sass-binary-site'] ||
              process.env.SASS_BINARY_SITE  ||
-             package.nodeSassConfig.binarySite;
-	return [site, 'v' + package.version, sass.binaryName].join('/');
+             pkg.nodeSassConfig.binarySite;
+	return [site, 'v' + pkg.version, sass.binaryName].join('/');
 }
 
 
@@ -138,8 +138,8 @@ sass.getBinaryPath = function(throwIfNotExists) {
     binaryPath = flags['--sass-binary-path'];
   } else if (process.env.SASS_BINARY_PATH) {
     binaryPath = process.env.SASS_BINARY_PATH;
-  } else if (package.nodeSassConfig && package.nodeSassConfig.binaryPath) {
-    binaryPath = package.nodeSassConfig.binaryPath;
+  } else if (pkg.nodeSassConfig && pkg.nodeSassConfig.binaryPath) {
+    binaryPath = pkg.nodeSassConfig.binaryPath;
   } else {
     binaryPath = path.join(__dirname, '..', 'vendor', sass.binaryName.replace(/_/, '/'));
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@
 var eol = require('os').EOL,
     path = require('path'),
     util = require('util'),
-    package = require('../package.json');
+    pkg = require('../package.json');
 
 require('./extensions');
 
@@ -23,7 +23,7 @@ var binding = require(process.sass.getBinaryPath(true));
 
 function getVersionInfo(binding) {
   return [
-           ['node-sass', package.version, '(Wrapper)', '[JavaScript]'].join('\t'),
+           ['node-sass', pkg.version, '(Wrapper)', '[JavaScript]'].join('\t'),
            ['libsass  ', binding.libsassVersion(), '(Sass Compiler)', '[C/C++]'].join('\t'),
   ].join(eol);
 }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -7,7 +7,7 @@ var fs = require('fs'),
     npmconf = require('npmconf'),
     path = require('path'),
     request = require('request'),
-    package = require('../package.json');
+    pkg = require('../package.json');
 
 require('../lib/extensions');
 
@@ -33,7 +33,7 @@ function download(url, dest, cb) {
     options.headers = {
       'User-Agent': [
         'node/', process.version, ' ',
-        'node-sass-installer/', package.version
+        'node-sass-installer/', pkg.version
       ].join('')
     };
     try {


### PR DESCRIPTION
`package` is a reserved word in strict mode. Therefore, node-sass cannot be packaged by a bundler that forces strict mode.

This pull request removes the `package` keyword, and renames the variable to `pkg`, as it is in `scripts/build.js`.