### PR TITLE
Revert "build: Adds win_delay_hook so iojs runs with alias."

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mkdirp": "^0.5.0",
     "nan": "^1.8.4",
     "npmconf": "^2.1.1",
-    "pangyp": "am11/pangyp",
+    "pangyp": "^2.1.0",
     "request": "^2.55.0",
     "sass-graph": "^2.0.0"
   },


### PR DESCRIPTION
This PR reverts commit 579baf322ca48f73b04a009b70220a6c0a3cbc15.

This is causing a lot of issues for people trying to install node-sass on windows. Two main culprits are proxy blocking git ports, or the local system not having git installed.

Fixes https://github.com/sass/node-sass/issues/939.
Fixes https://github.com/sass/node-sass/issues/933.
Closed https://github.com/sass/node-sass/pull/931.