### PR TITLE
Switch back to official pangyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mkdirp": "^0.5.0",
     "nan": "^1.8.4",
     "npmconf": "^2.1.1",
-    "pangyp": "https://github.com/am11/pangyp/archive/f13599f5198b853948429062c2b334010a337342.tar.gz",
+    "pangyp": "^2.2.0",
     "request": "^2.55.0",
     "sass-graph": "^2.0.0"
   },


### PR DESCRIPTION
This PR switches node-sass back to official pangyp now that https://github.com/rvagg/pangyp/pull/5 is in stable.

/cc @am11 @saper 