### PR TITLE
Fix ability to watch whole directory

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -199,9 +199,15 @@ function getOptions(args, options) {
  */
 
 function watch(options, emitter) {
-  var src = options.directory ? path.join(options.directory, globPattern(options)) : options.src;
-  var graph = grapher.parseDir(path.resolve(path.dirname(src)), { loadPaths: options.includePath });
   var watch = [];
+
+  var graphOptions = {loadPaths: options.includePath};
+  var graph;
+  if (options.directory) {
+    graph = grapher.parseDir(options.directory, graphOptions);
+  } else {
+    graph = grapher.parseFile(options.src, graphOptions);
+  }
 
   // Add all files to watch list
   for (var i in graph.index) {

--- a/test/cli.js
+++ b/test/cli.js
@@ -310,6 +310,31 @@ describe('cli', function() {
         fs.appendFileSync(foo, 'body{background:white}\n');
       }, 500);
     });
+
+    it('should watch whole directory', function(done) {
+      var destDir = fixture('watching-css-out/');
+      var srcDir = fixture('watching-dir/');
+      var srcFile = path.join(srcDir, 'index.scss');
+
+      fs.writeFileSync(srcFile, '');
+
+      var bin = spawn(cli, [
+        '--output-style', 'compressed',
+        '--output', destDir,
+        '--watch', srcDir
+      ]);
+
+      setTimeout(function () {
+        fs.appendFileSync(srcFile, 'a {color:green;}\n');
+        setTimeout(function () {
+          bin.kill();
+          var files = fs.readdirSync(destDir);
+          assert.deepEqual(files, ['index.css']);
+          rimraf.sync(destDir);
+          done();
+        }, 200);
+      }, 500);
+    });
   });
 
   describe('node-sass in.scss --output out.css', function() {

--- a/test/fixtures/watching-dir/index.scss
+++ b/test/fixtures/watching-dir/index.scss
@@ -1,0 +1,1 @@
+a {color:green;}


### PR DESCRIPTION
Fixing watch behavior for full directory. Currently barks on glob pattern in filename.