### PR TITLE
CLI: Adds source-map=directory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,8 @@ Pass a directory as the input to compile multiple files. For example: `node-sass
 
 Also, note `--importer` takes the (absolute or relative to pwd) path to a js file, which needs to have a default `module.exports` set to the importer function. See our test [fixtures](https://github.com/sass/node-sass/tree/974f93e76ddd08ea850e3e663cfe64bb6a059dd3/test/fixtures/extras) for example.
 
+The source-map option accepts `true` as value, in which case it replaces destination extension with `.css.map`. It also accepts path to `.map` file and even path to the desired directory. In case of multi-file compilation path to `.map` yields error.
+
 ## Post-install Build
 
 Install runs only two Mocha tests to see if your machine can use the pre-built [libsass] which will save some time during install. If any tests fail it will build from source.

--- a/bin/node-sass
+++ b/bin/node-sass
@@ -106,7 +106,7 @@ var cli = meow({
 function isDirectory(filePath) {
   var isDir = false;
   try {
-    var absolutePath = path.resolve(process.cwd(), filePath);
+    var absolutePath = path.resolve(filePath);
     isDir = fs.lstatSync(absolutePath).isDirectory();
   } catch (e) {
     isDir = e.code === 'ENOENT';
@@ -173,18 +173,42 @@ function getOptions(args, options) {
   options.src = args[0];
 
   if (args[1]) {
-    options.dest = path.resolve(process.cwd(), args[1]);
+    options.dest = path.resolve(args[1]);
   } else if (options.output) {
     options.dest = path.join(
-      path.resolve(process.cwd(), options.output),
+      path.resolve(options.output),
       [path.basename(options.src, path.extname(options.src)), '.css'].join(''));  // replace ext.
   }
 
   if (options.directory) {
-    var sassDir = path.resolve(process.cwd(), options.directory);
+    var sassDir = path.resolve(options.directory);
     var file = path.relative(sassDir, args[0]);
-    var cssDir = path.resolve(process.cwd(), options.output);
+    var cssDir = path.resolve(options.output);
     options.dest = path.join(cssDir, file).replace(path.extname(file), '.css');
+  }
+
+  if (options.sourceMap) {
+    if(!options.sourceMapOriginal) {
+      options.sourceMapOriginal = options.sourceMap;
+    }
+
+    // check if sourceMap path ends with .map to avoid isDirectory false-positive
+    var sourceMapIsDirectory = options.sourceMapOriginal.indexOf('.map', options.sourceMapOriginal.length - 4) === -1 && isDirectory(options.sourceMapOriginal);
+
+    if (options.sourceMapOriginal === 'true') {
+      options.sourceMap = options.dest + '.map';
+    } else if (!sourceMapIsDirectory) {
+      options.sourceMap = path.resolve(options.sourceMapOriginal);
+    } else if (sourceMapIsDirectory) {
+      if (!options.directory) {
+        options.sourceMap = path.resolve(options.sourceMapOriginal, path.basename(options.dest) + '.map');
+      } else {
+        var sassDir = path.resolve(options.directory);
+        var file = path.relative(sassDir, args[0]);
+        var mapDir = path.resolve(options.sourceMapOriginal);
+        options.sourceMap = path.join(mapDir, file).replace(path.extname(file), '.css.map');
+      }
+    }
   }
 
   return options;
@@ -201,7 +225,7 @@ function getOptions(args, options) {
 function watch(options, emitter) {
   var watch = [];
 
-  var graphOptions = {loadPaths: options.includePath};
+  var graphOptions = { loadPaths: options.includePath };
   var graph;
   if (options.directory) {
     graph = grapher.parseDir(options.directory, graphOptions);
@@ -253,24 +277,15 @@ function run(options, emitter) {
     }
   }
 
-  if (options.sourceMap) {
-    if (options.sourceMap === 'true') {
-      if (options.dest) {
-        options.sourceMap = options.dest + '.map';
-      } else {
-        // replace ext.
-        options.sourceMap = [path.basename(options.src, path.extname(options.src)), '.css.map'].join('');
-      }
-    } else {
-      options.sourceMap = path.resolve(process.cwd(), options.sourceMap);
-    }
+  if (options.sourceMapOriginal && options.directory && !isDirectory(options.sourceMapOriginal) && options.sourceMapOriginal !== 'true') {
+    emitter.emit('error', 'Multi-file compilation: requires sourceMap to be a directory or "true".');
   }
 
   if (options.importer) {
     if ((path.resolve(options.importer) === path.normalize(options.importer).replace(/(.+)([\/|\\])$/, '$1'))) {
       options.importer = require(options.importer);
     } else {
-      options.importer = require(path.resolve(process.cwd(), options.importer));
+      options.importer = require(path.resolve(options.importer));
     }
   }
 
@@ -278,7 +293,7 @@ function run(options, emitter) {
     if ((path.resolve(options.functions) === path.normalize(options.functions).replace(/(.+)([\/|\\])$/, '$1'))) {
       options.functions = require(options.functions);
     } else {
-      options.functions = require(path.resolve(process.cwd(), options.functions));
+      options.functions = require(path.resolve(options.functions));
     }
   }
 
@@ -315,13 +330,14 @@ function renderFile(file, options, emitter) {
  * @api private
  */
 function renderDir(options, emitter) {
-  var globPath = path.resolve(process.cwd(), options.directory, globPattern(options));
-  glob(globPath, {ignore: '**/_*'}, function(err, files) {
-    if(err) {
+  var globPath = path.resolve(options.directory, globPattern(options));
+  glob(globPath, { ignore: '**/_*' }, function(err, files) {
+    if (err) {
       return emitter.emit('error', util.format('You do not have permission to access this path: %s.', err.path));
-    } else if(!files.length) {
+    } else if (!files.length) {
       return emitter.emit('error', 'No input file was found.');
     }
+
     forEach(files, function(subject) {
       emitter.once('done', this.async());
       renderFile(subject, options, emitter);
@@ -359,7 +375,7 @@ if (!options.src && process.stdin.isTTY) {
  */
 
 if (options.src) {
-  if (isDirectory(options.src)){
+  if (isDirectory(options.src)) {
     options.directory = options.src;
   }
   run(options, emitter);

--- a/lib/render.js
+++ b/lib/render.js
@@ -81,14 +81,19 @@ module.exports = function(options, emitter) {
     if (options.sourceMap) {
       todo++;
 
-      fs.writeFile(options.sourceMap, result.map, function(err) {
+      mkdirp(path.dirname(options.sourceMap), function(err) {
         if (err) {
-          return emitter.emit('error', chalk.red('Error' + err));
+          return emitter.emit('error', chalk.red(err));
         }
+        fs.writeFile(options.sourceMap, result.map, function(err) {
+          if (err) {
+            return emitter.emit('error', chalk.red('Error' + err));
+          }
 
-        emitter.emit('warn', chalk.green('Wrote Source Map to ' + options.sourceMap));
-        emitter.emit('write-source-map', err, options.sourceMap, result.map);
-        done();
+          emitter.emit('warn', chalk.green('Wrote Source Map to ' + options.sourceMap));
+          emitter.emit('write-source-map', err, options.sourceMap, result.map);
+          done();
+        });
       });
     }
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -324,9 +324,9 @@ describe('cli', function() {
         '--watch', srcDir
       ]);
 
-      setTimeout(function () {
+      setTimeout(function() {
         fs.appendFileSync(srcFile, 'a {color:green;}\n');
-        setTimeout(function () {
+        setTimeout(function() {
           bin.kill();
           var files = fs.readdirSync(destDir);
           assert.deepEqual(files, ['index.css']);
@@ -420,7 +420,7 @@ describe('cli', function() {
       });
     });
 
-    it('it should compile all files in the folder', function(done) {
+    it('should compile all files in the folder', function(done) {
       var src = fixture('input-directory/sass');
       var dest = fixture('input-directory/css');
       var bin = spawn(cli, [src, '--output', dest]);
@@ -431,6 +431,22 @@ describe('cli', function() {
         var nestedFiles = fs.readdirSync(path.join(dest, 'nested'));
         assert.deepEqual(nestedFiles, ['three.css']);
         rimraf.sync(dest);
+        done();
+      });
+    });
+
+    it('should compile with --source-map set to directory', function(done) {
+      var src = fixture('input-directory/sass');
+      var dest = fixture('input-directory/css');
+      var destMap = fixture('input-directory/map');
+      var bin = spawn(cli, [src, '--output', dest, '--source-map', destMap]);
+
+      bin.once('close', function() {
+        var map = JSON.parse(read(fixture('input-directory/map/nested/three.css.map'), 'utf8'));
+
+        assert.equal(map.file, '../../css/nested/three.css');
+        rimraf.sync(dest);
+        rimraf.sync(destMap);
         done();
       });
     });


### PR DESCRIPTION
* For multi-file compilation.
* Written test.
* Usage:

  ```javascript
  node-sass --source-map source-map/dir --output css/path style/src/
  ```

Issue URL: #903.
PR URL: #964.