### PR TITLE
Fix multi-file compile only writes to the last path when multiple files import a changed partial

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -42,6 +42,10 @@ module.exports = function(options, emitter) {
     renderOptions.file = options.src;
   }
 
+  var sourceMap = options.sourceMap;
+  var destination = options.dest;
+  var stdin = options.stdin;
+
   var success = function(result) {
     var todo = 1;
     var done = function() {
@@ -50,10 +54,10 @@ module.exports = function(options, emitter) {
       }
     };
 
-    if (!options.dest || options.stdin) {
+    if (!destination || stdin) {
       emitter.emit('log', result.css.toString());
 
-      if (options.sourceMap) {
+      if (sourceMap) {
         emitter.emit('log', result.map.toString());
       }
 
@@ -62,36 +66,36 @@ module.exports = function(options, emitter) {
 
     emitter.emit('warn', chalk.green('Rendering Complete, saving .css file...'));
 
-    mkdirp(path.dirname(options.dest), function(err) {
+    mkdirp(path.dirname(destination), function(err) {
       if (err) {
         return emitter.emit('error', chalk.red(err));
       }
 
-      fs.writeFile(options.dest, result.css.toString(), function(err) {
+      fs.writeFile(destination, result.css.toString(), function(err) {
         if (err) {
           return emitter.emit('error', chalk.red(err));
         }
 
-        emitter.emit('warn', chalk.green('Wrote CSS to ' + options.dest));
-        emitter.emit('write', err, options.dest, result.css.toString());
+        emitter.emit('warn', chalk.green('Wrote CSS to ' + destination));
+        emitter.emit('write', err, destination, result.css.toString());
         done();
       });
     });
 
-    if (options.sourceMap) {
+    if (sourceMap) {
       todo++;
 
-      mkdirp(path.dirname(options.sourceMap), function(err) {
+      mkdirp(path.dirname(sourceMap), function(err) {
         if (err) {
           return emitter.emit('error', chalk.red(err));
         }
-        fs.writeFile(options.sourceMap, result.map, function(err) {
+        fs.writeFile(sourceMap, result.map, function(err) {
           if (err) {
             return emitter.emit('error', chalk.red('Error' + err));
           }
 
-          emitter.emit('warn', chalk.green('Wrote Source Map to ' + options.sourceMap));
-          emitter.emit('write-source-map', err, options.sourceMap, result.map);
+          emitter.emit('warn', chalk.green('Wrote Source Map to ' + sourceMap));
+          emitter.emit('write-source-map', err, sourceMap, result.map);
           done();
         });
       });

--- a/test/cli.js
+++ b/test/cli.js
@@ -335,6 +335,31 @@ describe('cli', function() {
         }, 200);
       }, 500);
     });
+
+    it('should compile all changed files in watched directory', function(done) {
+      var destDir = fixture('watching-css-out/');
+      var srcDir = fixture('watching/');
+      var srcFile = path.join(srcDir, 'foo.scss');
+
+      fs.writeFileSync(srcFile, '');
+
+      var bin = spawn(cli, [
+        '--output-style', 'compressed',
+        '--output', destDir,
+        '--watch', srcDir
+      ]);
+
+      setTimeout(function () {
+        fs.appendFileSync(srcFile, 'body{background:white}\n');
+        setTimeout(function () {
+          bin.kill();
+          var files = fs.readdirSync(destDir);
+          assert.deepEqual(files, ['foo.css', 'index.css']);
+          rimraf.sync(destDir);
+          done();
+        }, 200);
+      }, 500);
+    });
   });
 
   describe('node-sass in.scss --output out.css', function() {


### PR DESCRIPTION
Due to object passed by reference
closes https://github.com/sass/node-sass/issues/967

Possibly conflicting change with https://github.com/sass/node-sass/pull/964 I'll rebase when sourcemap support will be merged