### PR TITLE
Release v3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sass",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "libsass": "3.2.4",
   "description": "Wrapper around libsass",
   "license": "MIT",


### PR DESCRIPTION
## Fixes

- Fixed multi-file compilation sometimes writing to wrong file (#967, @kkopachev)
- Fixed multi-file compilation missing source maps (#903, @am11)

## Notes

>The source-map option accepts `true` as value, in which case it replaces destination extension with `.css.map`. It also accepts path to `.map` file and even path to the desired directory. In case of multi-file compilation path to `.map` yields error.