### PR TITLE
Release 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sass",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "libsass": "3.2.5",
   "description": "Wrapper around libsass",
   "license": "MIT",


### PR DESCRIPTION
This PR tracks the 3.2.0 release.

## TODO

- [x] Bump Libsass 3.2.5 (https://github.com/sass/node-sass/pull/992)
- [x] Create binaries
  - [x] Windows (@am11)
  - [x] FreeBSD (@saper)
  - [x] OSX (@xzyfer)
  - [x] Linux (@xzyfer)

## Release notes

```
## Features

- Updated Libsass to 3.2.5 (@xzyfer, #992)
```