### PR TITLE
[TEST] Failing Windows builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+
 ## Contributing
  * Fork the project.
  * Make your feature addition or bug fix.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,10 +6,7 @@ environment:
   SKIP_SASS_BINARY_DOWNLOAD_FOR_CI: true
   matrix:
     # node.js
-    - nodejs_version: 0.10
-    - nodejs_version: 0    # will fetch the latest node.js version
-    # io.js
-    - nodejs_version: 1    # will fetch the latest io.js version
+    - nodejs_version: 0.12.2    # will fetch the latest node.js version
 
 matrix:
   allow_failures:
@@ -17,9 +14,14 @@ matrix:
 
 install:
   - ps: Install-Product node $env:nodejs_version
+  - npm -g install https://github.com/npm/npm.git#6c22e33
+  - cd C:\Users\appveyor\AppData\Roaming\npm
+  - C:\"Program Files (x86)"\nodejs\npm.cmd install
+  - cd C:\projects\node-sass
   - node --version
   - npm --version
+  - C:\Users\appveyor\AppData\Roaming\npm\npm.cmd --version
   - git submodule update --init --recursive
-  - ps: npm install --msvs_version=2013
+  - ps: C:\Users\appveyor\AppData\Roaming\npm\npm.cmd install --msvs_version=2013
 
 test_script: npm test


### PR DESCRIPTION
This PR locks JShint to ~2.7 in order to prevent it incorrectly failing Windows builds.