### PR TITLE
Support libsass string quotes in the c/js api bindings.

### DIFF
--- a/src/sass_types/string.cpp
+++ b/src/sass_types/string.cpp
@@ -25,6 +25,8 @@ namespace SassTypes
   void String::initPrototype(Handle<ObjectTemplate> proto) {
     proto->Set(NanNew("getValue"), NanNew<FunctionTemplate>(GetValue)->GetFunction());
     proto->Set(NanNew("setValue"), NanNew<FunctionTemplate>(SetValue)->GetFunction());
+    proto->Set(NanNew("isQuoted"), NanNew<FunctionTemplate>(IsQuoted)->GetFunction());
+    proto->Set(NanNew("setQuoted"), NanNew<FunctionTemplate>(SetQuoted)->GetFunction());
   }
 
   NAN_METHOD(String::GetValue) {
@@ -42,6 +44,24 @@ namespace SassTypes
     }
 
     sass_string_set_value(unwrap(args.This())->value, create_string(args[0]));
+    NanReturnUndefined();
+  }
+
+  NAN_METHOD(String::IsQuoted) {
+    NanScope();
+    NanReturnValue(NanNew(sass_string_is_quoted(unwrap(args.This())->value)));
+  }
+
+  NAN_METHOD(String::SetQuoted) {
+    if (args.Length() != 1) {
+      return NanThrowError(NanNew("Expected just one argument"));
+    }
+
+    if (!args[0]->IsBoolean()) {
+      return NanThrowError(NanNew("Supplied value should be a boolean"));
+    }
+
+    sass_string_set_quoted(unwrap(args.This())->value, args[0]->ToBoolean()->Value());
     NanReturnUndefined();
   }
 }

--- a/src/sass_types/string.h
+++ b/src/sass_types/string.h
@@ -18,6 +18,9 @@ namespace SassTypes
 
       static NAN_METHOD(GetValue);
       static NAN_METHOD(SetValue);
+
+      static NAN_METHOD(IsQuoted);
+      static NAN_METHOD(SetQuoted);
   };
 }
 

--- a/test/api.js
+++ b/test/api.js
@@ -1228,6 +1228,29 @@ describe('api', function() {
       done();
     });
 
+    it('should handle quoted strings', function(done) {
+      var result = sass.renderSync({
+        data: '.swapped { result: swap-quotes("asdf", qwerty); }',
+        functions: {
+          'swap-quotes($s1, $s2)': function(s1, s2) {
+            s1.setQuoted(!s1.isQuoted());
+            s2.setQuoted(!s2.isQuoted());
+            console.log("s1: " + s1.isQuoted());
+            console.log("s2: " + s2.isQuoted());
+            var list = new sass.types.List(2);
+            list.setValue(0, s1);
+            list.setValue(1, s2);
+            list.setSeparator(true);
+
+            return list;
+          }
+        }
+      });
+
+      assert.equal(result.css.toString().trim(), '.swapped { result: asdf, "qwerty"; }');
+      done();
+    });
+
     it('should let custom function invoke sass types constructors without the `new` keyword', function(done) {
       var result = sass.renderSync({
         data: 'div { color: foo(); }',


### PR DESCRIPTION
This code compiles but the tests fail and I'm not sure why -- I think it might be a libsass bug. I could use some help debugging it.