### PR TITLE
Don't launch npm in the PowerShell

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,10 +17,9 @@ matrix:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm -g install npm@2.7.5
   - node --version
   - npm --version
   - git submodule update --init --recursive
-  - ps: C:\Users\appveyor\AppData\Roaming\npm\npm.cmd install --msvs_version=2013
+  - npm install --msvs_version=2013
 
 test_script: npm test


### PR DESCRIPTION
There might be issues with running npm under PS,
therefore let's run npm under CMD.

https://github.com/sass/node-sass/issues/996

http://help.appveyor.com/discussions/problems/2347-npm-275prefer-global-warning-causes-failure-command-executed-with-exception#comment_37223989

https://github.com/npm/npm/issues/8517

Effectively reverts: https://github.com/sass/node-sass/pull/995