### PR TITLE
Provide nodeSassConfig hardcoded defaults

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -104,7 +104,9 @@ function getBinaryName() {
 function getBinaryUrl() {
   var site = flags['--sass-binary-site'] ||
              process.env.SASS_BINARY_SITE  ||
-             pkg.nodeSassConfig.binarySite;
+             (pkg.nodeSassConfig && pkg.nodeSassConfig.binarySite) ||
+             'https://github.com/sass/node-sass/releases/download';
+
 	return [site, 'v' + pkg.version, sass.binaryName].join('/');
 }
 


### PR DESCRIPTION
Some private npm repositiories seem not to carry
custom package.json properties around.

Fixes: #1030