### PR TITLE
The watch should watch indented syntax files too

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -225,7 +225,7 @@ function getOptions(args, options) {
 function watch(options, emitter) {
   var watch = [];
 
-  var graphOptions = { loadPaths: options.includePath };
+  var graphOptions = { loadPaths: options.includePath, extensions: ['scss', 'sass', 'css'] };
   var graph;
   if (options.directory) {
     graph = grapher.parseDir(options.directory, graphOptions);

--- a/test/cli.js
+++ b/test/cli.js
@@ -288,7 +288,7 @@ describe('cli', function() {
       }, 500);
     });
 
-    it('should watch the full sass dep tree for a single file', function(done) {
+    it('should watch the full scss dep tree for a single file', function(done) {
       var src = fixture('watching/index.scss');
       var foo = fixture('watching/foo.scss');
 
@@ -308,6 +308,29 @@ describe('cli', function() {
 
       setTimeout(function() {
         fs.appendFileSync(foo, 'body{background:white}\n');
+      }, 500);
+    });
+
+    it('should watch the full sass dep tree for a single file', function(done) {
+      var src = fixture('watching/index.sass');
+      var foo = fixture('watching/bar.sass');
+
+      fs.writeFileSync(foo, '');
+
+      var bin = spawn(cli, [
+        '--output-style', 'compressed',
+        '--watch', src
+      ]);
+
+      bin.stdout.setEncoding('utf8');
+      bin.stdout.once('data', function(data) {
+        assert(data.trim() === 'body{background:white}');
+        bin.kill();
+        done();
+      });
+
+      setTimeout(function() {
+        fs.appendFileSync(foo, 'body\n\tbackground: white\n');
       }, 500);
     });
 

--- a/test/fixtures/watching/bar.sass
+++ b/test/fixtures/watching/bar.sass
@@ -1,0 +1,2 @@
+body
+	background: white

--- a/test/fixtures/watching/index.sass
+++ b/test/fixtures/watching/index.sass
@@ -1,0 +1,1 @@
+@import "bar.sass";


### PR DESCRIPTION
This fixes a bug that prevented the watcher from triggering file compilations on changes to .sass file.

Fixes #1075