### PR TITLE
Make Travis CI to report failures on io.js 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ node_js:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - node_js: iojs
 
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
Seems like we didn't catch serious failures reported by Travis CI on after #1058. Make io.js 3.0 compliance mandatory now.