### PR TITLE
Handle MaybeLocal value from the constructor

### DIFF
--- a/src/sass_types/sass_value_wrapper.h
+++ b/src/sass_types/sass_value_wrapper.h
@@ -106,8 +106,12 @@ namespace SassTypes
       }
     } else {
       v8::Local<v8::Function> cons = T::get_constructor();
-      v8::Local<v8::Object> inst = Nan::NewInstance(cons, info.Length(), &localArgs[0]).ToLocalChecked();
-      info.GetReturnValue().Set(inst);
+      v8::Local<v8::Object> inst;
+      if (Nan::NewInstance(cons, info.Length(), &localArgs[0]).ToLocal(&inst)) {
+        info.GetReturnValue().Set(inst);
+      } else {
+        info.GetReturnValue().Set(Nan::Undefined());
+      }
     }
   }
 


### PR DESCRIPTION
In case of exception occuring during construction
of a Sass type instance just return Undefined value,
as the delayed JS exception will pop up later.

The following code:

    var sass = require('./');
        sass.render({
        data: 'div { color: foo(); }',
          functions: {
            'foo()': function() {
              return sass.types.Color(2,3);
            }
          }
    });

now results in an libsass error

     Constructor should be invoked with either 0, 1, 3 or 4 arguments

instead of V8 abort

     FATAL ERROR: v8::ToLocalChecked Empty MaybeLocal

Fixes https://github.com/sass/node-sass/issues/1090