### PR TITLE
Be explicit about which runtime versions travis should test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,12 @@ env: SKIP_SASS_BINARY_DOWNLOAD_FOR_CI=true
 compiler: gcc
 
 node_js:
-  - 0.10
-  - node  # will fetch the latest node.js version
-  - iojs  # will fetch the latest io.js version
+  - "0.10"
+  - "0.12"
+  - "iojs-v1.0"
+  - "iojs-v1"
+  - "iojs-v2"
+  - "iojs-v3"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
This PR updates our travis ci config to be more explicit about which runtime versions to run. 
It also makes sure we're running tests against all supported runtime versions.