### PR TITLE
CI: Adds explicit runtime versions in job matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,13 +7,11 @@ environment:
   matrix:
     # node.js
     - nodejs_version: 0.10
-    - nodejs_version: 0    # will fetch the latest node.js version
+    - nodejs_version: 0.12
     # io.js
-    - nodejs_version: 1    # will fetch the latest io.js version
-
-matrix:
-  allow_failures:
     - nodejs_version: 1
+    - nodejs_version: 2
+    - nodejs_version: 3
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,3 +21,12 @@ install:
   - npm install --msvs_version=2013
 
 test_script: npm test
+
+on_success:
+# Save artifact with full qualified names of binding.node
+# (which we use in node-sass-binaries repo)
+- ps: Get-ChildItem .\vendor\**\*.node | % `
+      {
+        Push-AppveyorArtifact $_.FullName -FileName
+        (($_.FullName.Split('\\') | Select-Object -Last 2) -join '_')
+      }

--- a/package.json
+++ b/package.json
@@ -49,25 +49,25 @@
   ],
   "dependencies": {
     "async-foreach": "^0.1.3",
-    "chalk": "^1.0.0",
+    "chalk": "^1.1.1",
     "gaze": "^0.5.1",
     "get-stdin": "^4.0.1",
-    "glob": "^5.0.13",
+    "glob": "^5.0.14",
     "meow": "^3.3.0",
     "mkdirp": "^0.5.1",
-    "nan": "^2.0.1",
+    "nan": "^2.0.5",
     "npmconf": "^2.1.2",
-    "pangyp": "^2.2.1",
-    "request": "^2.58.0",
-    "sass-graph": "^2.0.0"
+    "pangyp": "^2.3.0",
+    "request": "^2.61.0",
+    "sass-graph": "^2.0.1"
   },
   "devDependencies": {
-    "coveralls": "^2.11.2",
-    "cross-spawn": "^1.0.3",
-    "istanbul": "^0.3.13",
+    "coveralls": "^2.11.4",
+    "cross-spawn": "^2.0.0",
+    "istanbul": "^0.3.18",
     "jshint": "^2.8.0",
     "mocha": "^2.2.5",
     "mocha-lcov-reporter": "^0.0.2",
-    "rimraf": "^2.4.1"
+    "rimraf": "^2.4.2"
   }
 }


### PR DESCRIPTION
* CI: Adds explicit runtime versions in job matrix.
  Updates appveyor.yml.

  Related: #1096
* CI: Stores build artifact (binding.node) for job. 
  * The artifact will be available under job details in `Artifacts` tab
  * URL format: `https://ci.appveyor.com/project/sass/node-sass/build/<build-id>/job/<job-id>/artifacts`
* Package: Updates to latest versions.
