### PR TITLE
Use build cache for NPM and GYP files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ after_success: npm run-script coverage
 
 cache:
   directories:
+    - $HOME/.node-gyp
+    - $HOME/.npm
     - node_modules
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,10 @@ version: "{build}"
 
 build: off
 
+cache:  
+  - c:\Users\appveyor\.node-gyp
+  - '%AppData%\npm-cache'
+
 environment:
   SKIP_SASS_BINARY_DOWNLOAD_FOR_CI: true
   matrix:


### PR DESCRIPTION
To speed up a build and avoid bombarding
nodejs.org and iojs.org with connections we should
cache what we download via npm and node-gyp.

Note: %AppData% [does not seem to presently work](https://help.appveyor.com/discussions/problems/2869-appdata-causes-error-parsing-appveyoryml-while-scanning-for-the-next-token-find-character-that-cannot-start-any-token) there.

Related:

  https://github.com/nodejs/nodejs.org/issues/167
  https://help.appveyor.com/discussions/problems/2849-intermittently-unable-to-connect-to-nodejsorg