### PR TITLE
Use process.config.target_defaults.default_configuration as the build type default

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -20,7 +20,9 @@ require('../lib/extensions');
 
 function afterBuild(options) {
   var install = process.sass.binaryPath;
-  var target = path.join(__dirname, '..', 'build', options.debug ? 'Debug' : 'Release', 'binding.node');
+  var target = path.join(__dirname, '..', 'build',
+    options.debug ? 'Debug' : process.config.target_defaults.default_configuration,
+    'binding.node');
 
   mkdir(path.dirname(install), function(err) {
     if (err && err.code !== 'EEXIST') {


### PR DESCRIPTION
`node-gyp` is using `process.config.target_defaults.default_configuration`
to check which configuration is about to be used, but this
can be overriden by particular engine's `config.gypi` file.
    
Since we do not support such a cross compilation anyway,
use this variable in place of a hardcoded default.
    
Instead of introducing another option to force the use
of 'Release' we should read and pass options to node-gyp.
This is not implemented here.

Fixes https://github.com/sass/node-sass/issues/1077