### PR TITLE
Workaround the segfault that occurs when used with fsevents

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     "request": "^2.61.0",
     "sass-graph": "^2.0.1"
   },
+  "optionalDependencies": {
+    "fsevents": "0.3.7"
+  },
   "devDependencies": {
     "coveralls": "^2.11.4",
     "cross-spawn": "^2.0.0",


### PR DESCRIPTION
`fsevents@0.3.8` introduces a segfault that manifests when used with node-sass https://github.com/strongloop/fsevents/issues/82


`fsevents` is widely popular. As a mitigation we've added `fsevents@0.3.7` as an `optionalDependency`. The intention here is the prevent users install `node-sass@3.3.x` and `fsevents@0.3.8` by using npm's deduping behaviour.

Adding `optionalDependency` will cause npm to dedupe the package and install the most suitable version. Since we've pinned to a specific version ours will always be the most suitable.

This is certainly cause us problems in the long run and should be reverted as soon as issue fixed upstream.