### PR TITLE
Use libstdc++.so.6.0.9 to workaround static init problems

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -57,8 +57,7 @@
         ['OS=="mac"', {
           'xcode_settings': {
             'OTHER_CPLUSPLUSFLAGS': [
-              '-std=c++11',
-              '-stdlib=libc++'
+              '-std=c++11'
             ],
             'OTHER_LDFLAGS': [],
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',

--- a/binding.gyp
+++ b/binding.gyp
@@ -62,7 +62,6 @@
             ],
             'OTHER_LDFLAGS': [],
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
-            'GCC_ENABLE_CPP_RTTI': 'YES',
             'MACOSX_DEPLOYMENT_TARGET': '10.7'
           }
         }],
@@ -70,7 +69,6 @@
           'msvs_settings': {
             'VCCLCompilerTool': {
               'AdditionalOptions': [
-                '/GR',
                 '/EHsc'
               ]
             }

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -123,11 +123,12 @@ int ExtractOptions(v8::Local<v8::Object> options, void* cptr, sass_context_wrapp
 
   if (importer_callback->IsFunction()) {
     v8::Local<v8::Function> importer = importer_callback.As<v8::Function>();
-    auto bridge = std::make_shared<CustomImporterBridge>(new Nan::Callback(importer), ctx_w->is_sync);
+
+    CustomImporterBridge *bridge = new CustomImporterBridge(importer, ctx_w->is_sync);
     ctx_w->importer_bridges.push_back(bridge);
 
     Sass_Importer_List c_importers = sass_make_importer_list(1);
-    c_importers[0] = sass_make_importer(sass_importer, 0, bridge.get());
+    c_importers[0] = sass_make_importer(sass_importer, 0, bridge);
 
     sass_option_set_c_importers(sass_options, c_importers);
   }
@@ -138,10 +139,10 @@ int ExtractOptions(v8::Local<v8::Object> options, void* cptr, sass_context_wrapp
     for (size_t i = 0; i < importers->Length(); ++i) {
       v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(Nan::Get(importers, static_cast<uint32_t>(i)).ToLocalChecked());
 
-      auto bridge = std::make_shared<CustomImporterBridge>(new Nan::Callback(callback), ctx_w->is_sync);
+      CustomImporterBridge *bridge = new CustomImporterBridge(callback, ctx_w->is_sync);
       ctx_w->importer_bridges.push_back(bridge);
 
-      c_importers[i] = sass_make_importer(sass_importer, importers->Length() - i - 1, bridge.get());
+      c_importers[i] = sass_make_importer(sass_importer, importers->Length() - i - 1, bridge);
     }
 
     sass_option_set_c_importers(sass_options, c_importers);
@@ -159,10 +160,10 @@ int ExtractOptions(v8::Local<v8::Object> options, void* cptr, sass_context_wrapp
       v8::Local<v8::String> signature = v8::Local<v8::String>::Cast(Nan::Get(signatures, Nan::New(i)).ToLocalChecked());
       v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(Nan::Get(functions, signature).ToLocalChecked());
 
-      auto bridge = std::make_shared<CustomFunctionBridge>(new Nan::Callback(callback), ctx_w->is_sync);
+      CustomFunctionBridge *bridge = new CustomFunctionBridge(callback, ctx_w->is_sync);
       ctx_w->function_bridges.push_back(bridge);
 
-      Sass_Function_Entry fn = sass_make_function(create_string(signature), sass_custom_function, bridge.get());
+      Sass_Function_Entry fn = sass_make_function(create_string(signature), sass_custom_function, bridge);
       sass_function_set_list_entry(fn_list, i, fn);
     }
 

--- a/src/callback_bridge.h
+++ b/src/callback_bridge.h
@@ -3,8 +3,8 @@
 
 #include <vector>
 #include <nan.h>
-#include <condition_variable>
 #include <algorithm>
+#include <uv.h>
 
 #define COMMA ,
 
@@ -42,8 +42,8 @@ class CallbackBridge {
     Nan::Callback* callback;
     bool is_sync;
 
-    std::mutex cv_mutex;
-    std::condition_variable condition_variable;
+    uv_mutex_t cv_mutex;
+    uv_cond_t condition_variable;
     uv_async_t *async;
     std::vector<L> argv;
     bool has_returned;
@@ -60,6 +60,8 @@ CallbackBridge<T, L>::CallbackBridge(Nan::Callback* callback, bool is_sync) : ca
    * V8 context is available.
    */
   Nan::HandleScope scope;
+  uv_mutex_init(&this->cv_mutex);
+  uv_cond_init(&this->condition_variable);
   if (!is_sync) {
     this->async = new uv_async_t;
     this->async->data = (void*) this;
@@ -75,6 +77,8 @@ template <typename T, typename L>
 CallbackBridge<T, L>::~CallbackBridge() {
   delete this->callback;
   this->wrapper.Reset();
+  uv_cond_destroy(&this->condition_variable);
+  uv_mutex_destroy(&this->cv_mutex);
 
   if (!is_sync) {
     uv_close((uv_handle_t*)this->async, &async_gone);
@@ -117,11 +121,13 @@ T CallbackBridge<T, L>::operator()(std::vector<void*> argv) {
      */
     this->argv = argv;
 
-    std::unique_lock<std::mutex> lock(this->cv_mutex);
+    uv_mutex_lock(&this->cv_mutex);
     this->has_returned = false;
     uv_async_send(this->async);
-    this->condition_variable.wait(lock, [this] { return this->has_returned; });
-
+    while (!this->has_returned) {
+      uv_cond_wait(&this->condition_variable, &this->cv_mutex);
+    }
+    uv_mutex_unlock(&this->cv_mutex);
     return this->return_value;
   }
 }
@@ -168,11 +174,12 @@ NAN_METHOD(CallbackBridge<T COMMA L>::ReturnCallback) {
   bridge->return_value = bridge->post_process_return_value(info[0]);
 
   {
-    std::lock_guard<std::mutex> lock(bridge->cv_mutex);
+    uv_mutex_lock(&bridge->cv_mutex);
     bridge->has_returned = true;
+    uv_mutex_unlock(&bridge->cv_mutex);
   }
 
-  bridge->condition_variable.notify_all();
+  uv_cond_broadcast(&bridge->condition_variable);
 
   if (try_catch.HasCaught()) {
     Nan::FatalException(try_catch);

--- a/src/callback_bridge.h
+++ b/src/callback_bridge.h
@@ -11,7 +11,7 @@
 template <typename T, typename L = void*>
 class CallbackBridge {
   public:
-    CallbackBridge(Nan::Callback*, bool);
+    CallbackBridge(v8::Local<v8::Function>, bool);
     virtual ~CallbackBridge();
 
     // Executes the callback
@@ -54,7 +54,7 @@ template <typename T, typename L>
 Nan::Persistent<v8::Function> CallbackBridge<T, L>::wrapper_constructor;
 
 template <typename T, typename L>
-CallbackBridge<T, L>::CallbackBridge(Nan::Callback* callback, bool is_sync) : callback(callback), is_sync(is_sync) {
+CallbackBridge<T, L>::CallbackBridge(v8::Local<v8::Function> callback, bool is_sync) : callback(new Nan::Callback(callback)), is_sync(is_sync) {
   /* 
    * This is invoked from the main JavaScript thread.
    * V8 context is available.

--- a/src/custom_function_bridge.cpp
+++ b/src/custom_function_bridge.cpp
@@ -1,4 +1,5 @@
 #include <nan.h>
+#include <stdexcept>
 #include "custom_function_bridge.h"
 #include "sass_types/factory.h"
 

--- a/src/custom_function_bridge.h
+++ b/src/custom_function_bridge.h
@@ -7,7 +7,7 @@
 
 class CustomFunctionBridge : public CallbackBridge<Sass_Value*> {
   public:
-    CustomFunctionBridge(Nan::Callback* cb, bool is_sync) : CallbackBridge<Sass_Value*>(cb, is_sync) {}
+    CustomFunctionBridge(v8::Local<v8::Function> cb, bool is_sync) : CallbackBridge<Sass_Value*>(cb, is_sync) {}
 
   private:
     Sass_Value* post_process_return_value(v8::Local<v8::Value>) const;

--- a/src/custom_importer_bridge.cpp
+++ b/src/custom_importer_bridge.cpp
@@ -1,4 +1,5 @@
 #include <nan.h>
+#include <stdexcept>
 #include "custom_importer_bridge.h"
 #include "create_string.h"
 

--- a/src/custom_importer_bridge.h
+++ b/src/custom_importer_bridge.h
@@ -9,7 +9,7 @@ typedef Sass_Import_List SassImportList;
 
 class CustomImporterBridge : public CallbackBridge<SassImportList> {
   public:
-    CustomImporterBridge(Nan::Callback* cb, bool is_sync) : CallbackBridge<SassImportList>(cb, is_sync) {}
+    CustomImporterBridge(v8::Local<v8::Function> cb, bool is_sync) : CallbackBridge<SassImportList>(cb, is_sync) {}
 
   private:
     SassImportList post_process_return_value(v8::Local<v8::Value>) const;

--- a/src/sass_context_wrapper.cpp
+++ b/src/sass_context_wrapper.cpp
@@ -46,8 +46,18 @@ extern "C" {
     free(ctx_w->source_map_root);
     free(ctx_w->indent);
 
-    ctx_w->importer_bridges.resize(0);
-    ctx_w->function_bridges.resize(0);
+    std::vector<CustomImporterBridge *>::iterator imp_it = ctx_w->importer_bridges.begin();
+    while (imp_it != ctx_w->importer_bridges.end()) {
+      CustomImporterBridge* p = *imp_it;
+      imp_it = ctx_w->importer_bridges.erase(imp_it);
+      delete p;
+    }
+    std::vector<CustomFunctionBridge *>::iterator func_it = ctx_w->function_bridges.begin();
+    while (func_it != ctx_w->function_bridges.end()) {
+      CustomFunctionBridge* p = *func_it;
+      func_it = ctx_w->function_bridges.erase(func_it);
+      delete p;
+    }
 
     free(ctx_w);
   }

--- a/src/sass_context_wrapper.h
+++ b/src/sass_context_wrapper.h
@@ -42,8 +42,8 @@ extern "C" {
     Nan::Callback* error_callback;
     Nan::Callback* success_callback;
 
-    std::vector<std::shared_ptr<CustomFunctionBridge>> function_bridges;
-    std::vector<std::shared_ptr<CustomImporterBridge>> importer_bridges;
+    std::vector<CustomFunctionBridge *> function_bridges;
+    std::vector<CustomImporterBridge *> importer_bridges;
   };
 
   struct sass_context_wrapper*      sass_make_context_wrapper(void);

--- a/src/sass_context_wrapper.h
+++ b/src/sass_context_wrapper.h
@@ -5,7 +5,6 @@
 #include <memory>
 #include <nan.h>
 #include <stdlib.h>
-#include <condition_variable>
 #include <sass_context.h>
 #include "custom_function_bridge.h"
 #include "custom_importer_bridge.h"


### PR DESCRIPTION
libsass needs to be linked against libc++ from clang
on MacOSX to use advanced C++11 functions.

The binding code is not that picky and we can try
to link against whatever is the default.
Mixing C++ runtime libraries is still very bad, but
we should be able to avoid crash when being
used with another node module using nan.h
and its GetWrapper() static cache:

https://github.com/strongloop/fsevents/issues/82