### PR TITLE
Revert "Workaround the segfault that occurs when used with fsevents"

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,9 +61,6 @@
     "request": "^2.61.0",
     "sass-graph": "^2.0.1"
   },
-  "optionalDependencies": {
-    "fsevents": "0.3.7"
-  },
   "devDependencies": {
     "coveralls": "^2.11.4",
     "cross-spawn": "^2.0.0",


### PR DESCRIPTION
This reverts commit 3166b613fd17f1182e99a9e46fd9e355d3dfb8e1.

Not needed any more after update to nan 2.0.8 and
enabling the use of libstdc++.so.6 for the binding.