### PR TITLE
Standardise on cross-spawn for spawning child processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "async-foreach": "^0.1.3",
     "chalk": "^1.1.1",
+    "cross-spawn": "^2.0.0",
     "gaze": "^0.5.1",
     "get-stdin": "^4.0.1",
     "glob": "^5.0.14",
@@ -63,7 +64,6 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.4",
-    "cross-spawn": "^2.0.0",
     "istanbul": "^0.3.18",
     "jshint": "^2.8.0",
     "mocha": "^2.2.5",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -7,7 +7,7 @@ var eol = require('os').EOL,
     fs = require('fs'),
     mkdir = require('mkdirp'),
     path = require('path'),
-    spawn = require('child_process').spawn;
+    spawn = require('cross-spawn');
 
 require('../lib/extensions');
 


### PR DESCRIPTION
There a known issues with `spawn` on Windows i.e. joyent/node#2318.
As a work around we sometimes use [cross-spawn](https://www.npmjs.com/package/cross-spawn). We will move all usage of `spawn` to `cross-spawn`.

Closes #1015.