### PR TITLE
Update reference of 'multi-file' to 'directory'

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,11 +470,11 @@ node scripts/build -f  # use -d switch for debug release
 
 The interface for command-line usage is fairly simplistic at this stage, as seen in the following usage section.
 
-Output will be saved with the same name as input SASS file into the current working directory if it's omitted.
+Output will be saved with the same name as input Sass file into the current working directory if the `--output` flag is omitted.
 
 ### Usage
- `node-sass [options] <input.scss> [output.css]`
- `cat <input.scss> | node-sass > output.css`
+ `node-sass [options] <input> [output]`
+ `cat <input> | node-sass > output`
 
  **Options:**
 
@@ -502,11 +502,12 @@ Output will be saved with the same name as input SASS file into the current work
     --help                     Print usage info
 ```
 
-Pass a directory as the input to compile multiple files. For example: `node-sass sass/ -o css/`. The `--output` flag is required and must be a directory when using multi-file compilation.
+The `input` can be either a single `.scss` or `.sass`, or a directory. If the input is a directory the `--output` flag must also be supplied.
 
 Also, note `--importer` takes the (absolute or relative to pwd) path to a js file, which needs to have a default `module.exports` set to the importer function. See our test [fixtures](https://github.com/sass/node-sass/tree/974f93e76ddd08ea850e3e663cfe64bb6a059dd3/test/fixtures/extras) for example.
 
-The source-map option accepts `true` as value, in which case it replaces destination extension with `.css.map`. It also accepts path to `.map` file and even path to the desired directory. In case of multi-file compilation path to `.map` yields error.
+The `--source-map` option accepts a boolean value, in which case it replaces destination extension with `.css.map`. It also accepts path to `.map` file and even path to the desired directory. 
+When compiling a directory `--source-map` can either be a boolean value or a directory.
 
 ## Post-install Build
 

--- a/bin/node-sass
+++ b/bin/node-sass
@@ -270,15 +270,15 @@ function run(options, emitter) {
 
   if (options.directory) {
     if (!options.output) {
-      emitter.emit('error', 'Specify an output directory when using multi-file compilation');
+      emitter.emit('error', 'An output directory must be specified when compiling a directory');
     }
     if (!isDirectory(options.output)) {
-      emitter.emit('error', util.format('Multi-file compilation: requires destination %s to be a directory.', options.output));
+      emitter.emit('error', 'An output directory must be specified when compiling a directory');
     }
   }
 
   if (options.sourceMapOriginal && options.directory && !isDirectory(options.sourceMapOriginal) && options.sourceMapOriginal !== 'true') {
-    emitter.emit('error', 'Multi-file compilation: requires sourceMap to be a directory or "true".');
+    emitter.emit('error', 'The --source-map option must be either a boolean or directory when compiling a directory');
   }
 
   if (options.importer) {


### PR DESCRIPTION
The multi-file terminology is unintuitive and could be seen as suggesting we support multiple input files, when in fact we're describing directory support.

Fixes https://github.com/sass/node-sass/issues/985