### PR TITLE
CLI: add --follow option

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ Output will be saved with the same name as input Sass file into the current work
     --source-map-embed         Embed sourceMappingUrl as data URI
     --source-map-root          Base path, will be emitted in source-map as is
     --include-path             Path to look for imported files
+    --follow                   Follow symlinked directories
     --precision                The amount of precision allowed in decimal numbers
     --importer                 Path to .js file containing custom importer
     --functions                Path to .js file containing custom functions
@@ -506,7 +507,7 @@ The `input` can be either a single `.scss` or `.sass`, or a directory. If the in
 
 Also, note `--importer` takes the (absolute or relative to pwd) path to a js file, which needs to have a default `module.exports` set to the importer function. See our test [fixtures](https://github.com/sass/node-sass/tree/974f93e76ddd08ea850e3e663cfe64bb6a059dd3/test/fixtures/extras) for example.
 
-The `--source-map` option accepts a boolean value, in which case it replaces destination extension with `.css.map`. It also accepts path to `.map` file and even path to the desired directory. 
+The `--source-map` option accepts a boolean value, in which case it replaces destination extension with `.css.map`. It also accepts path to `.map` file and even path to the desired directory.
 When compiling a directory `--source-map` can either be a boolean value or a directory.
 
 ## Post-install Build

--- a/bin/node-sass
+++ b/bin/node-sass
@@ -46,6 +46,7 @@ var cli = meow({
     '  --source-map-embed         Embed sourceMappingUrl as data URI',
     '  --source-map-root          Base path, will be emitted in source-map as is',
     '  --include-path             Path to look for imported files',
+    '  --follow                   Follow symlinked directories',
     '  --precision                The amount of precision allowed in decimal numbers',
     '  --importer                 Path to .js file containing custom importer',
     '  --functions                Path to .js file containing custom functions',
@@ -54,6 +55,7 @@ var cli = meow({
 }, {
   boolean: [
     'indented-syntax',
+    'follow',
     'omit-source-map-url',
     'quiet',
     'recursive',
@@ -331,7 +333,7 @@ function renderFile(file, options, emitter) {
  */
 function renderDir(options, emitter) {
   var globPath = path.resolve(options.directory, globPattern(options));
-  glob(globPath, { ignore: '**/_*' }, function(err, files) {
+  glob(globPath, { ignore: '**/_*', follow: options.follow }, function(err, files) {
     if (err) {
       return emitter.emit('error', util.format('You do not have permission to access this path: %s.', err.path));
     } else if (!files.length) {

--- a/test/cli.js
+++ b/test/cli.js
@@ -578,14 +578,14 @@ describe('cli', function() {
       var src = fixture('follow/input-dir');
       var dest = fixture('follow/output-dir');
 
-      fs.mkdirSync(src)
-      fs.symlinkSync(path.join(path.dirname(src), 'foo'), path.join(src, 'foo'), 'dir')
+      fs.mkdirSync(src);
+      fs.symlinkSync(path.join(path.dirname(src), 'foo'), path.join(src, 'foo'), 'dir');
 
       var bin = spawn(cli, [src, '--follow', '--output', dest]);
 
       bin.once('close', function() {
         var expected = path.join(dest, 'foo/bar/index.css');
-        fs.unlinkSync(path.join(path.dirname(src), 'foo'));
+        fs.unlinkSync(path.join(src, 'foo'));
         fs.rmdirSync(src);
         assert(fs.existsSync(expected));
         fs.unlinkSync(expected);

--- a/test/cli.js
+++ b/test/cli.js
@@ -573,6 +573,32 @@ describe('cli', function() {
 
   });
 
+  describe('node-sass --follow --output output-dir input-dir', function() {
+    it('should compile with the --follow option', function(done) {
+      var src = fixture('follow/input-dir');
+      var dest = fixture('follow/output-dir');
+
+      fs.mkdirSync(src)
+      fs.symlinkSync(path.join(path.dirname(src), 'foo'), path.join(src, 'foo'), 'dir')
+
+      var bin = spawn(cli, [src, '--follow', '--output', dest]);
+
+      bin.once('close', function() {
+        var expected = path.join(dest, 'foo/bar/index.css');
+        fs.unlinkSync(path.join(path.dirname(src), 'foo'));
+        fs.rmdirSync(src);
+        assert(fs.existsSync(expected));
+        fs.unlinkSync(expected);
+        expected = path.dirname(expected);
+        fs.rmdirSync(expected);
+        expected = path.dirname(expected);
+        fs.rmdirSync(expected);
+        fs.rmdirSync(dest);
+        done();
+      });
+    });
+  });
+
   describe('importer', function() {
     var dest = fixture('include-files/index.css');
     var src = fixture('include-files/index.scss');

--- a/test/fixtures/follow/foo/bar/index.scss
+++ b/test/fixtures/follow/foo/bar/index.scss
@@ -1,0 +1,16 @@
+#navbar {
+  width: 80%;
+  height: 23px;
+}
+
+#navbar ul {
+  list-style-type: none;
+}
+
+#navbar li {
+  float: left;
+
+  a {
+    font-weight: bold;
+  }
+}


### PR DESCRIPTION
Follow symlinked subdirectories when using --follow option. 
Note that this can result in a lot of duplicate references in the presence of cyclic links.
But it really helpful in a specific situations.