### PR TITLE
Show actual compiler flags when building

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -130,7 +130,7 @@ function build(options) {
       process.exit(1);
     }
 
-    var args = [require.resolve(path.join('pangyp', 'bin', 'node-gyp.js')), 'rebuild'].concat(
+    var args = [require.resolve(path.join('pangyp', 'bin', 'node-gyp.js')), 'rebuild', '--verbose'].concat(
       ['libsass_ext', 'libsass_cflags', 'libsass_ldflags', 'libsass_library'].map(function(subject) {
         return ['--', subject, '=', process.env[subject.toUpperCase()] || ''].join('');
       })).concat(options.args);


### PR DESCRIPTION
Make the build process output actually
useful.