### PR TITLE
Add Node.js 4 to AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,8 @@ environment:
     - nodejs_version: 1
     - nodejs_version: 2
     - nodejs_version: 3
+    # node
+    - nodejs_version: 4
 
 install:
   - ps: Install-Product node $env:nodejs_version


### PR DESCRIPTION
This PR adds Node.js 4 support to AppVeyor matching the Travis config (https://github.com/sass/node-sass/pull/1130)