### PR TITLE
AppVeyor: fully automated build of 32- and 64-bit Windows binaries

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,35 +1,86 @@
-version: "{build}"
+-
+  branches:
+    only:
+      - release
 
-build: off
+  configuration: release
 
-cache:  
-  - c:\Users\appveyor\.node-gyp
-  - '%AppData%\npm-cache'
+  platform:
+    - x64
+    - x86
 
-environment:
-  SKIP_SASS_BINARY_DOWNLOAD_FOR_CI: true
-  matrix:
-    - nodejs_version: 0.10
-    - nodejs_version: 0.12
-    - nodejs_version: 1
-    - nodejs_version: 2
-    - nodejs_version: 3
-    - nodejs_version: 4
+  version: "{build}"
 
-install:
-  - ps: Install-Product node $env:nodejs_version
-  - node --version
-  - npm --version
-  - git submodule update --init --recursive
-  - npm install --msvs_version=2013
+  build: off
 
-test_script: npm test
+  cache:  
+    - '%userprofile%\.node-gyp'
+    - '%AppData%\npm-cache'
 
-on_success:
-# Save artifact with full qualified names of binding.node
-# (which we use in node-sass-binaries repo)
-- ps: Get-ChildItem .\vendor\**\*.node | % `
-      {
-        Push-AppveyorArtifact $_.FullName -FileName
-        (($_.FullName.Split('\\') | Select-Object -Last 2) -join '_')
-      }
+  environment:
+    SKIP_SASS_BINARY_DOWNLOAD_FOR_CI: true
+    matrix:
+      - nodejs_version: 0.10
+      - nodejs_version: 0.12
+      - nodejs_version: 1
+      - nodejs_version: 2
+      - nodejs_version: 3
+      - nodejs_version: 4
+
+  install:
+    - ps: Install-Product node $env:nodejs_version $env:platform
+    - node --version
+    - npm --version
+    - git submodule update --init --recursive
+    - npm install --msvs_version=2013
+
+  test_script: npm test
+
+  before_deploy:
+    # Save artifact with full qualified names of binding.node
+    # (which we use in node-sass-binaries repo)
+    - ps: Get-ChildItem .\vendor\**\*.node | % { Push-AppveyorArtifact $_.FullName -FileName (($_.FullName.Split('\\') | Select-Object -Last 2) -join '_') }
+
+
+  deploy:
+    - provider: GitHub
+      description: $(APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED)
+      artifact: /.*binding\.node/           # upload all NuGet packages to release assets
+      auth_token:
+        secure: tt+p58W9Q49faww/o0CODJI8e++YEX5THVlpXlRIigO4xHjE8NKigi0oxr1b2PJE
+      on:
+        branch: release               # release from master branch only
+        appveyor_repo_tag: true       # deploy on tag push only
+
+-
+  configuration: testing
+
+  platform:
+    - x86
+
+  version: "{build}"
+
+  build: off
+
+  cache:  
+    - '%userprofile%\.node-gyp'
+    - '%AppData%\npm-cache'
+
+  environment:
+    SKIP_SASS_BINARY_DOWNLOAD_FOR_CI: true
+    matrix:
+      - nodejs_version: 0.10
+      - nodejs_version: 0.12
+      - nodejs_version: 1
+      - nodejs_version: 2
+      - nodejs_version: 3
+      - nodejs_version: 4
+
+  install:
+    - ps: Install-Product node $env:nodejs_version $env:platform
+    - node --version
+    - npm --version
+    - git submodule update --init --recursive
+    - npm install --msvs_version=2013
+
+  test_script: npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@
     matrix:
       - nodejs_version: 0.10
       - nodejs_version: 0.12
+      - nodejs_version: 1.0
       - nodejs_version: 1
       - nodejs_version: 2
       - nodejs_version: 3


### PR DESCRIPTION
For pull requests and pushes to master just build 32-bit binaries
and do not store artifacts.

Whenever a tag is pushed to the "release" branch - produce
full set of 32-bit and 64-bit binaries, create a GitHub
release (if does not exist already) and attach the binaries
to the release.

Issues open:

http://bit.ly/twoBuilds

 AppVeyor starts two builds in response to the "new commit"
 and "new tag" events.

http://bit.ly/bad_build_success

 Parse error in the appveyor.yml causes the system to
 silently ignore the commit.

http://bit.ly/appvLessDup

 Is there a way to remove duplicate stanzas from
 both configurations?