### PR TITLE
Use sass binary url from .npmrc if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,28 @@ Also, note `--importer` takes the (absolute or relative to pwd) path to a js fil
 The `--source-map` option accepts a boolean value, in which case it replaces destination extension with `.css.map`. It also accepts path to `.map` file and even path to the desired directory. 
 When compiling a directory `--source-map` can either be a boolean value or a directory.
 
+## Binary configuration parameters
+
+node-sass supports different configuration parameters to change settings related to the sass binary such as binary name, binary path or alternative download path. Following parameters are supported by node-sass:
+
+Variable name    | .npmrc parameter | Process argument   | Value
+-----------------|------------------|--------------------|------
+SASS_BINARY_NAME | sass_binary_name | --sass-binary-name | path
+SASS_BINARY_SITE | sass_binary_site | --sass-binary-site | URL
+SASS_BINARY_PATH | sass_binary_path | --sass-binary-path | path
+
+These parameters can be used as environment variable:
+
+* E.g. `export SASS_BINARY_SITE=http://example.com/`
+
+As local or global [.npmrc](https://docs.npmjs.com/misc/config) configuration file:
+
+* E.g. `sass_binary_site=http://example.com/`
+
+As a process argument:
+
+* E.g. `npm install node-sass --SASS_BINARY_SITE=http://example.com/`
+
 ## Post-install Build
 
 Install runs only two Mocha tests to see if your machine can use the pre-built [libsass] which will save some time during install. If any tests fail it will build from source.

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -48,7 +48,8 @@ function getRuntimeInfo() {
 
 /**
  * Get binary name.
- * If environment variable SASS_BINARY_NAME or
+ * If environment variable SASS_BINARY_NAME,
+ * .npmrc variable sass_binary_name or
  * process argument --binary-name is provided,
  * return it as is, otherwise make default binary
  * name: {platform}-{arch}-{v8 version}.node
@@ -63,6 +64,8 @@ function getBinaryName() {
     binaryName = flags['--sass-binary-name'];
   } else if (process.env.SASS_BINARY_NAME) {
     binaryName = process.env.SASS_BINARY_NAME;
+  } else if (process.env.npm_config_sass_binary_name) {
+    binaryName = process.env.npm_config_sass_binary_name;
   } else if (pkg.nodeSassConfig && pkg.nodeSassConfig.binaryName) {
     binaryName = pkg.nodeSassConfig.binaryName;
   } else {
@@ -80,7 +83,8 @@ function getBinaryName() {
  * site on GitHub.
  *
  * The default URL can be overriden using
- * the environment variable SASS_BINARY_SITE
+ * the environment variable SASS_BINARY_SITE,
+* .npmrc variable sass_binary_site or
  * or a command line option --sass-binary-site:
  *
  *   node scripts/install.js --sass-binary-site http://example.com/
@@ -104,6 +108,7 @@ function getBinaryName() {
 function getBinaryUrl() {
   var site = flags['--sass-binary-site'] ||
              process.env.SASS_BINARY_SITE  ||
+             process.env.npm_config_sass_binary_site ||
              (pkg.nodeSassConfig && pkg.nodeSassConfig.binarySite) ||
              'https://github.com/sass/node-sass/releases/download';
 
@@ -121,7 +126,8 @@ sass.runtime = getRuntimeInfo();
 
 /**
  * Get binary path.
- * If environment variable SASS_BINARY_PATH or
+ * If environment variable SASS_BINARY_PATH,
+ * .npmrc variable sass_binary_path or
  * process argument --sass-binary-path is provided,
  * select it by appending binary name, otherwise
  * make default binary path using binary name.
@@ -140,6 +146,8 @@ sass.getBinaryPath = function(throwIfNotExists) {
     binaryPath = flags['--sass-binary-path'];
   } else if (process.env.SASS_BINARY_PATH) {
     binaryPath = process.env.SASS_BINARY_PATH;
+  } else if (process.env.npm_config_sass_binary_path) {
+    binaryPath = process.env.npm_config_sass_binary_path;
   } else if (pkg.nodeSassConfig && pkg.nodeSassConfig.binaryPath) {
     binaryPath = pkg.nodeSassConfig.binaryPath;
   } else {

--- a/test/runtime.js
+++ b/test/runtime.js
@@ -24,176 +24,117 @@ describe('runtime parameters', function() {
       require(extensionsPath);
     });
 
-    describe('in package.json', function() {
-      it('should use the binary path', function() {
-        require.cache[packagePath].exports.nodeSassConfig = { binaryPath: 'ccc' };
-        require(extensionsPath);
+    describe('configuration precedence should be respected', function() {
 
-        assert.equal(process.sass.binaryPath, 'ccc');
+      describe('SASS_BINARY_NAME', function() {
+        beforeEach(function() {
+          process.argv.push('--sass-binary-name', 'aaa');
+          process.env.SASS_BINARY_NAME = 'bbb';
+          process.env.npm_config_sass_binary_name = 'ccc';
+          require.cache[packagePath].exports.nodeSassConfig = { binaryName: 'ddd' };
+        });
+
+        it('command line argument', function() {
+          require(extensionsPath);
+          assert.equal(process.sass.binaryName, 'aaa_binding.node');
+        });
+
+        it('environment variable', function() {
+          process.argv = [];
+          require(extensionsPath);
+          assert.equal(process.sass.binaryName, 'bbb_binding.node');
+        });
+
+        it('npm config variable', function() {
+          process.argv = [];
+          process.env.SASS_BINARY_NAME = null;
+          require(extensionsPath);
+          assert.equal(process.sass.binaryName, 'ccc_binding.node');
+        });
+
+        it('package.json', function() {
+          process.argv = [];
+          process.env.SASS_BINARY_NAME = null;
+          process.env.npm_config_sass_binary_name = null;
+          require(extensionsPath);
+          assert.equal(process.sass.binaryName, 'ddd_binding.node');
+        });
       });
 
-      it('should use the binary file name', function() {
-        require.cache[packagePath].exports.nodeSassConfig = { binaryName: 'ddd' };
-        require(extensionsPath);
+      describe('SASS_BINARY_SITE', function() {
+        beforeEach(function() {
+          process.argv.push('--sass-binary-site', 'http://aaa.example.com:9999');
+          process.env.SASS_BINARY_SITE = 'http://bbb.example.com:8888';
+          process.env.npm_config_sass_binary_site = 'http://ccc.example.com:7777';
+          require.cache[packagePath].exports.nodeSassConfig = { binarySite: 'http://ddd.example.com:6666' };
+        });
 
-        assert.equal(process.sass.binaryName, 'ddd_binding.node');
+        it('command line argument', function() {
+          require(extensionsPath);
+          var URL = 'http://aaa.example.com:9999';
+          assert.equal(process.sass.binaryUrl.substr(0, URL.length), URL);
+        });
+
+        it('environment variable', function() {
+          process.argv = [];
+          require(extensionsPath);
+          var URL = 'http://bbb.example.com:8888';
+          assert.equal(process.sass.binaryUrl.substr(0, URL.length), URL);
+        });
+
+        it('npm config variable', function() {
+          process.argv = [];
+          process.env.SASS_BINARY_SITE = null;
+          require(extensionsPath);
+          var URL = 'http://ccc.example.com:7777';
+          assert.equal(process.sass.binaryUrl.substr(0, URL.length), URL);
+        });
+
+        it('package.json', function() {
+          process.argv = [];
+          process.env.SASS_BINARY_SITE = null;
+          process.env.npm_config_sass_binary_site = null;
+          require(extensionsPath);
+          var URL = 'http://ddd.example.com:6666';
+          assert.equal(process.sass.binaryUrl.substr(0, URL.length), URL);
+        });
       });
 
-      it('should use both the binary path and the file name', function() {
-        require.cache[packagePath].exports.nodeSassConfig = { binaryName: 'foo', binaryPath: 'bar' };
-        require(extensionsPath);
+      describe('SASS_BINARY_PATH', function() {
+        beforeEach(function() {
+          process.argv.push('--sass-binary-path', 'aaa_binding.node');
+          process.env.SASS_BINARY_PATH = 'bbb_binding.node';
+          process.env.npm_config_sass_binary_path = 'ccc_binding.node';
+          require.cache[packagePath].exports.nodeSassConfig = { binaryPath: 'ddd_binding.node' };
+        });
 
-        assert.equal(process.sass.binaryName, 'foo_binding.node');
-        assert.equal(process.sass.binaryPath, 'bar');
+        it('command line argument', function() {
+          require(extensionsPath);
+          assert.equal(process.sass.binaryPath, 'aaa_binding.node');
+        });
+
+        it('environment variable', function() {
+          process.argv = [];
+          require(extensionsPath);
+          assert.equal(process.sass.binaryPath, 'bbb_binding.node');
+        });
+
+        it('npm config variable', function() {
+          process.argv = [];
+          process.env.SASS_BINARY_PATH = null;
+          require(extensionsPath);
+          assert.equal(process.sass.binaryPath, 'ccc_binding.node');
+        });
+
+        it('package.json', function() {
+          process.argv = [];
+          process.env.SASS_BINARY_PATH = null;
+          process.env.npm_config_sass_binary_path = null;
+          require(extensionsPath);
+          assert.equal(process.sass.binaryPath, 'ddd_binding.node');
+        });
       });
 
-      it('should use both the binary path and the file name', function() {
-        require.cache[packagePath].exports.nodeSassConfig = { binaryName: 'foo', binaryPath: 'bar' };
-        require(extensionsPath);
-
-        assert.equal(process.sass.binaryName, 'foo_binding.node');
-        assert.equal(process.sass.binaryPath, 'bar');
-      });
-
-      it('should use the distribution site URL', function() {
-        require.cache[packagePath].exports.nodeSassConfig = { binarySite: 'http://foo.example.com:9999' };
-        require(extensionsPath);
-
-        var URL = 'http://foo.example.com:9999/v';
-        assert.equal(process.sass.binaryUrl.substr(0, URL.length), URL);
-      });
-
-    });
-
-    describe('in the process environment variables', function() {
-      it('should use the binary path', function() {
-        process.env.SASS_BINARY_PATH = 'xxx';
-        require(extensionsPath);
-
-        assert.equal(process.sass.binaryPath, 'xxx');
-      });
-
-      it('should use the binary file name', function() {
-        process.env.SASS_BINARY_NAME = 'foo';
-        require(extensionsPath);
-
-        assert.equal(process.sass.binaryName, 'foo_binding.node');
-      });
-
-      it('should use both the binary path and the file name', function() {
-        process.env.SASS_BINARY_NAME = 'foo';
-        process.env.SASS_BINARY_PATH = 'bar';
-        require(extensionsPath);
-
-        assert.equal(process.sass.binaryName, 'foo_binding.node');
-        assert.equal(process.sass.binaryPath, 'bar');
-      });
-
-      it('should use the distribution site URL', function() {
-        process.env.SASS_BINARY_SITE = 'http://bar.example.com:9988';
-        require(extensionsPath);
-
-        var URL = 'http://bar.example.com:9988/v';
-        assert.equal(process.sass.binaryUrl.substr(0, URL.length), URL);
-      });
-    });
-
-    describe('using command line parameters', function() {
-      it('should use the binary path', function() {
-        process.argv.push('--sass-binary-path', 'aaa');
-        require(extensionsPath);
-
-        assert.equal(process.sass.binaryPath, 'aaa');
-      });
-
-      it('should use the binary file name', function() {
-        process.argv.push('--sass-binary-name', 'bbb');
-        require(extensionsPath);
-
-        assert.equal(process.sass.binaryName, 'bbb_binding.node');
-      });
-
-      it('should use both the binary path and the file name', function() {
-        process.argv.push('--sass-binary-name', 'foo', '--sass-binary-path', 'bar');
-        require(extensionsPath);
-
-        assert.equal(process.sass.binaryName, 'foo_binding.node');
-        assert.equal(process.sass.binaryPath, 'bar');
-      });
-
-      it('should use the distribution site URL', function() {
-        process.argv.push('--sass-binary-site', 'http://qqq.example.com:9977');
-        require(extensionsPath);
-
-        var URL = 'http://qqq.example.com:9977/v';
-        assert.equal(process.sass.binaryUrl.substr(0, URL.length), URL);
-      });
-    });
-    describe('checking if the command line parameter overrides environment', function() {
-      it('binary path', function() {
-        process.argv.push('--sass-binary-path', 'bbb');
-        process.env.SASS_BINARY_PATH = 'xxx';
-        require(extensionsPath);
-        assert.equal(process.sass.binaryPath, 'bbb');
-      });
-      it('binary name', function() {
-        process.argv.push('--sass-binary-name', 'ccc');
-        process.env.SASS_BINARY_NAME = 'yyy';
-        require(extensionsPath);
-        assert.equal(process.sass.binaryName, 'ccc_binding.node');
-      });
-      it('distribution site URL', function() {
-        process.argv.push('--sass-binary-site', 'http://qqq.example.com:9977');
-        process.env.SASS_BINARY_SITE = 'http://www.example.com:9988';
-        require(extensionsPath);
-
-        var URL = 'http://qqq.example.com:9977/v';
-        assert.equal(process.sass.binaryUrl.substr(0, URL.length), URL);
-      });
-    });
-    describe('checking if the command line parameter overrides package.json', function() {
-      it('binary path', function() {
-        process.argv.push('--sass-binary-path', 'ddd');
-        require.cache[packagePath].exports.nodeSassConfig = { binaryPath: 'yyy' };
-        require(extensionsPath);
-        assert.equal(process.sass.binaryPath, 'ddd');
-      });
-      it('binary name', function() {
-        process.argv.push('--sass-binary-name', 'eee');
-        require.cache[packagePath].exports.nodeSassConfig = { binaryName: 'zzz' };
-        require(extensionsPath);
-        assert.equal(process.sass.binaryName, 'eee_binding.node');
-      });
-      it('distribution site URL', function() {
-        process.argv.push('--sass-binary-site', 'http://yyy.example.com:9977');
-        require.cache[packagePath].exports.nodeSassConfig = { binarySite: 'http://ddd.example.com:8888' };
-        require(extensionsPath);
-
-        var URL = 'http://yyy.example.com:9977/v';
-        assert.equal(process.sass.binaryUrl.substr(0, URL.length), URL);
-      });
-    });
-    describe('checking if environment variable overrides package.json', function() {
-      it('binary path', function() {
-        process.env.SASS_BINARY_PATH = 'ggg';
-        require.cache[packagePath].exports.nodeSassConfig = { binaryPath: 'qqq' };
-        require(extensionsPath);
-        assert.equal(process.sass.binaryPath, 'ggg');
-      });
-      it('binary name', function() {
-        process.env.SASS_BINARY_NAME = 'hhh';
-        require.cache[packagePath].exports.nodeSassConfig = { binaryName: 'uuu' };
-        require(extensionsPath);
-        assert.equal(process.sass.binaryName, 'hhh_binding.node');
-      });
-      it('distribution site URL', function() {
-        require.cache[packagePath].exports.nodeSassConfig = { binarySite: 'http://ddd.example.com:8888' };
-        process.env.SASS_BINARY_SITE = 'http://iii.example.com:9988';
-        require(extensionsPath);
-
-        var URL = 'http://iii.example.com:9988/v';
-        assert.equal(process.sass.binaryUrl.substr(0, URL.length), URL);
-      });
     });
 });
 


### PR DESCRIPTION
This PR adds the possibility to configure the sass-binary URL in the .npmrc configuration file (e.g.  `sass_cdnurl=http://example.com/sass-binaries`). This is also used the same way in [PhantomJS](https://github.com/Medium/phantomjs/blob/master/install.js#L23) by pointing the download URL to a mirror without having to set an environment variable manually.