### PR TITLE
Don't compile delay hook into libsass

### DIFF
--- a/src/libsass.gyp
+++ b/src/libsass.gyp
@@ -2,6 +2,7 @@
   'targets': [
     {
       'target_name': 'libsass',
+      'win_delay_load_hook': 'false',
       'type': 'static_library',
       'defines': [
          'LIBSASS_VERSION="<!(node -e "process.stdout.write(require(\'../package.json\').libsass)")"'


### PR DESCRIPTION
Windows delay hook feature is only needed
on the main module, linked into the shared
library. Don't compile and include
it second time in the bundled libsass.

Related: https://github.com/nodejs/node-gyp/issues/732