### PR TITLE
Disable flakey dependency watching tests

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -301,7 +301,7 @@ describe('cli', function() {
       }, 500);
     });
 
-    it('should watch the full scss dep tree for a single file (scss)', function(done) {
+    it.skip('should watch the full scss dep tree for a single file (scss)', function(done) {
       var src = fixture('watching/index.scss');
       var foo = fixture('watching/white.scss');
 
@@ -324,7 +324,7 @@ describe('cli', function() {
       }, 500);
     });
 
-    it('should watch the full sass dep tree for a single file (sass)', function(done) {
+    it.skip('should watch the full sass dep tree for a single file (sass)', function(done) {
       var src = fixture('watching/index.sass');
       var foo = fixture('watching/bar.sass');
 


### PR DESCRIPTION
Sometimes they generate double notification
on change:

      1) cli node-sass in.scss should watch the full scss dep tree for a single file (scss):

      Uncaught AssertionError: 'body{background:blue}\n\nbody{background:blue}' == 'body{background:blue}'
      + expected - actual

      -body{background:blue}
      -
       body{background:blue}

      at Socket.<anonymous> (test/cli.js:317:16)
      at readableAddChunk (_stream_readable.js:146:16)
      at Socket.Readable.push (_stream_readable.js:110:10)
      at Pipe.onread (net.js:523:20)

https://github.com/sass/node-sass/issues/1152