### PR TITLE
Add CLI option for watcher polling interval

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -47,6 +47,7 @@ var cli = meow({
     '  --source-map-root          Base path, will be emitted in source-map as is',
     '  --include-path             Path to look for imported files',
     '  --follow                   Follow symlinked directories',
+    '  --poll-interval            The filesystem polling interval in ms when the watcher has to poll',
     '  --precision                The amount of precision allowed in decimal numbers',
     '  --importer                 Path to .js file containing custom importer',
     '  --functions                Path to .js file containing custom functions',
@@ -240,7 +241,11 @@ function watch(options, emitter) {
     watch.push(i);
   }
 
-  var gaze = new Gaze();
+  if (options.pollInterval && typeof options.pollInterval !== 'number') {
+    emitter.emit('error', 'The --poll-interval must be an integer.');
+  }
+
+  var gaze = new Gaze(null, { interval: options.pollInterval });
   gaze.add(watch);
   gaze.on('error', emitter.emit.bind(emitter, 'error'));
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -11,7 +11,7 @@ var assert = require('assert'),
     LIBSASS_VERSION = null;
 
 describe('cli', function() {
-  
+
   before(function(done) {
       var bin = spawn(cli, ['-v']);
       bin.stdout.setEncoding('utf8');
@@ -233,6 +233,21 @@ describe('cli', function() {
           done();
         }
       }, 100);
+    });
+
+    it.only('should error when watching and --poll-interval is not an integer', function(done) {
+      var src = fixture('simple/tmp.scss');
+      var bin = spawn(cli, ['--watch', src]);
+      var didEmit = false;
+
+      bin.stderr.once('data', function() {
+        didEmit = true;
+      });
+
+      bin.once('close', function() {
+        assert.equal(didEmit, true);
+        done();
+      });
     });
 
     it('should emit `warn` on file change when using --watch option', function(done) {


### PR DESCRIPTION
In some environments the fs watcher falls back to polling for
changes. Both our current watcher and the proposed new watcher
both had support for user-defined polling intervals. I see no
reason not to add this for users who want extra control.

Fixes #801.