### PR TITLE
making sass logo size more appropriate

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <table>
   <tr>
     <td>
-      <img width="100%" alt="Sass logo" src="https://rawgit.com/sass/node-sass/master/media/logo.svg" />
+      <img width="77px" alt="Sass logo" src="https://rawgit.com/sass/node-sass/master/media/logo.svg" />
     </td>
     <td valign="bottom" align="right">
       <a href="https://nodei.co/npm/node-sass/">


### PR DESCRIPTION
This pull request addresses issue https://github.com/sass/node-sass/issues/1204. Sass logo has been made a more appropriate size (77px - fits nicely with the adjacent npm image)