### PR TITLE
The previous file should be the absolute path, not the string used to import it.

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -9,7 +9,7 @@ Sass_Import_List sass_importer(const char* cur_path, Sass_Importer_Entry cb, str
 {
   void* cookie = sass_importer_get_cookie(cb);
   struct Sass_Import* previous = sass_compiler_get_last_import(comp);
-  const char* prev_path = sass_import_get_imp_path(previous);
+  const char* prev_path = sass_import_get_abs_path(previous);
   CustomImporterBridge& bridge = *(static_cast<CustomImporterBridge*>(cookie));
 
   std::vector<void*> argv;


### PR DESCRIPTION
node-sass 3.4 had a breaking public API change. This patch fixes the path that is passed as the previous file path when resolving imports. In node-sass 3.4 this value changed so that the import uri was passed. The issue here is that any code needed to resolve one import against another quickly falls apart if the resolved path returned by the importer is not what is passed back to the importer as the current sass file.

Basically, I think the updates for node-sass 3.4 to use libsass 3.3 mistakenly used the wrong value.