### PR TITLE
Added a test for #1219

### DIFF
--- a/test/api.js
+++ b/test/api.js
@@ -186,6 +186,29 @@ describe('api', function() {
   describe('.render(importer)', function() {
     var src = read(fixture('include-files/index.scss'), 'utf8');
 
+    it('should still call the next importer with the resolved prev path when the previous importer returned both a file and contents property - issue #1219', function(done) {
+      sass.render({
+        data: '@import "a";',
+        importer: function(url, prev, done) {
+          if (url === 'a') {
+            done({
+              file: '/Users/me/sass/lib/a.scss',
+              contents: '@import "b"'
+            });
+          } else {
+          console.log(prev);
+            assert.equal(prev, '/Users/me/sass/lib/a.scss');
+            done({
+              file: '/Users/me/sass/lib/b.scss',
+              contents: 'div {color: yellow;}'
+            });
+          }
+        }
+      }, function(error, result) {
+        done();
+      });
+    });
+
     it('should override imports with "data" as input and fires callback with file and contents', function(done) {
       sass.render({
         data: src,

--- a/test/api.js
+++ b/test/api.js
@@ -204,7 +204,7 @@ describe('api', function() {
             });
           }
         }
-      }, function(error, result) {
+      }, function() {
         done();
       });
     });


### PR DESCRIPTION
Couldn't get the tests to run on my windows box:

    > mocha test

    fs.js:813
      return binding.readdir(pathModule._makeLong(path));
                 ^
    Error: ENOENT: no such file or directory, scandir 'C:\Development\node-sass-test-case\node-sass\test\fixtures\spec\spec'

but running the new test in it's own file works for `v3.3.3` and fails for `v3.4.1`:

    var sass = require('node-sass');
    var assert = require('assert');

    it('should still call the next importer with the resolved prev path when the previous importer returned both a file and contents property - issue #1219', function(done) {

      sass.render({
        data: '@import "a";',
        importer: function(url, prev, done) {
          if (url === 'a') {
            done({
              file: '/Users/me/sass/lib/a.scss',
              contents: '@import "b"'
            });
          } else {
          console.log(prev);
            assert.equal(prev, '/Users/me/sass/lib/a.scss');
            done({
              file: '/Users/me/sass/lib/b.scss',
              contents: 'div {color: yellow;}'
            });
          }
        }
      }, function(error, result) {
        done();
      });

    });