### PR TITLE
Use the last stable nvm, not the master version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,9 @@ before_install:
       export LINK="gcc-4.7";
       export LINKXX="g++-4.7";
     fi
+  - nvm --version
+  - node --version
+  - npm --version
   - gcc --version
   - g++ --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ addons:
 before_install:
   - git submodule update --init --recursive
   - git clone https://github.com/creationix/nvm.git ./.nvm
+  - git -C .nvm checkout "$(git -C .nvm describe --tags `git -C .nvm rev-list --tags --max-count=1`)"
   - source ./.nvm/nvm.sh
   - nvm install $NODE_VERSION
   - nvm use $NODE_VERSION


### PR DESCRIPTION
The nvm version from master is unsupported and may be broken. Using a tag
is advised.