### PR TITLE
Disable randomly failing watcher tests

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -278,7 +278,7 @@ describe('cli', function() {
       }, 500);
     });
 
-    it('should render all watched files', function(done) {
+    it.skip('should render all watched files', function(done) {
       var src = fixture('simple/bar.scss');
 
       fs.writeFileSync(src, '');


### PR DESCRIPTION
Until we can commit time to figuring out why they're failing randomly.