### PR TITLE
Update mocha dependency to >= 2.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "coveralls": "^2.11.4",
     "istanbul": "^0.3.18",
     "jshint": "^2.8.0",
-    "mocha": "^2.2.5",
+    "mocha": "^2.3.4",
     "mocha-lcov-reporter": "^0.0.2",
     "rimraf": "^2.4.2"
   }


### PR DESCRIPTION
That latest version includes an update (mochajs/mocha@039a8a7) to a newer version (2.2.0) of `debug`, which in turn has updated (visionmedia/debug@adc2402) its dependency on `ms` to 0.7.1 in order to include a [security fix](https://nodesecurity.io/advisories/46).

Untested!

Ideally, please also do a point release including this fixed dependency.