### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
       <img width="77px" alt="Sass logo" src="https://rawgit.com/sass/node-sass/master/media/logo.svg" />
     </td>
     <td valign="bottom" align="right">
-      <a href="https://nodei.co/npm/node-sass/">
+      <a href="https://www.npmjs.com/package/node-sass">
         <img width="100%" src="https://nodei.co/npm/node-sass.png?downloads=true&downloadRank=true&stars=true">
       </a>
     </td>
@@ -20,13 +20,13 @@
 [![devDependency Status](https://david-dm.org/sass/node-sass/dev-status.svg?theme=shields.io)](https://david-dm.org/sass/node-sass#info=devDependencies)
 [![Coverage Status](https://coveralls.io/repos/sass/node-sass/badge.svg?branch=master)](https://coveralls.io/r/sass/node-sass?branch=master)
 [![Inline docs](http://inch-ci.org/github/sass/node-sass.svg?branch=master)](http://inch-ci.org/github/sass/node-sass)
-[![Gitter chat](http://img.shields.io/badge/gitter-sass/node--sass-brightgreen.svg)](https://gitter.im/sass/node-sass)
+[![Gitter chat](https://img.shields.io/badge/gitter-sass/node--sass-brightgreen.svg)](https://gitter.im/sass/node-sass)
 
 Node-sass is a library that provides binding for Node.js to [libsass], the C version of the popular stylesheet preprocessor, Sass.
 
 It allows you to natively compile .scss files to css at incredible speed and automatically via a connect middleware.
 
-Find it on npm: <https://npmjs.org/package/node-sass>
+Find it on npm: <https://www.npmjs.com/package/node-sass>
 
 Follow @nodesass on twitter for release updates: https://twitter.com/nodesass
 
@@ -36,9 +36,9 @@ Follow @nodesass on twitter for release updates: https://twitter.com/nodesass
 npm install node-sass
 ```
 
-Some users have reported issues installing on Ubuntu due to `node` being registered to another package. [Follow the official NodeJS docs](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager) to install NodeJS so that `#!/usr/bin/env node` correctly resolved.
+Some users have reported issues installing on Ubuntu due to `node` being registered to another package. [Follow the official NodeJS docs](https://github.com/nodejs/node-v0.x-archive/wiki/Installing-Node.js-via-package-manager) to install NodeJS so that `#!/usr/bin/env node` correctly resolved.
 
-Compiling versions 0.9.4 and above on Windows machines requires [Visual Studio 2013 WD](http://www.visualstudio.com/downloads/download-visual-studio-vs#d-express-windows-desktop). If you have multiple VS versions, use ```npm install``` with the ```--msvs_version=2013``` flag also use this flag when rebuilding the module with node-gyp or nw-gyp.
+Compiling versions 0.9.4 and above on Windows machines requires [Visual Studio 2013 WD](https://www.visualstudio.com/downloads/download-visual-studio-vs#d-express-windows-desktop). If you have multiple VS versions, use ```npm install``` with the ```--msvs_version=2013``` flag also use this flag when rebuilding the module with node-gyp or nw-gyp.
 
 **Having installation troubles? Check out our [Troubleshooting guide](/TROUBLESHOOTING.md).**
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager | https://github.com/nodejs/node-v0.x-archive/wiki/Installing-Node.js-via-package-manager 


### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://img.shields.io/badge/gitter-sass/node--sass-brightgreen.svg | https://img.shields.io/badge/gitter-sass/node--sass-brightgreen.svg 
http://www.visualstudio.com/downloads/download-visual-studio-vs#d-express-windows-desktop | https://www.visualstudio.com/downloads/download-visual-studio-vs#d-express-windows-desktop 


### Other Corrected URLs 
Was | Now 
--- | --- 
https://nodei.co/npm/node-sass/ | https://www.npmjs.com/package/node-sass 
https://npmjs.org/package/node-sass | https://www.npmjs.com/package/node-sass 
