### PR TITLE
Handle sass.NULL returned from the importer via done()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -301,27 +301,27 @@ module.exports.render = function(options, cb) {
     if (Array.isArray(importer)) {
       importer.forEach(function(subject, index) {
         options.importer[index] = function(file, prev, bridge) {
-          function done(data) {
-            bridge.success(data);
+          function done(result) {
+            bridge.success(result === module.exports.NULL ? null : result);
           }
 
           var result = subject.call(options.context, file, prev, done);
 
-          if (result) {
-            done(result === module.exports.NULL ? null : result);
+          if (result !== undefined) {
+            done(result);
           }
         };
       });
     } else {
       options.importer = function(file, prev, bridge) {
-        function done(data) {
-          bridge.success(data);
+        function done(result) {
+          bridge.success(result === module.exports.NULL ? null : result);
         }
 
         var result = importer.call(options.context, file, prev, done);
 
-        if (result) {
-          done(result === module.exports.NULL ? null : result);
+        if (result !== undefined) {
+          done(result);
         }
       };
     }


### PR DESCRIPTION
Whenever done() is called we should check for the sass.NULL
value as well.

Fixes https://github.com/sass/node-sass/issues/1296