### PR TITLE
Handle sass.NULL returned from the importer via done()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -301,27 +301,27 @@ module.exports.render = function(options, cb) {
     if (Array.isArray(importer)) {
       importer.forEach(function(subject, index) {
         options.importer[index] = function(file, prev, bridge) {
-          function done(data) {
-            bridge.success(data);
+          function done(result) {
+            bridge.success(result === module.exports.NULL ? null : result);
           }
 
           var result = subject.call(options.context, file, prev, done);
 
-          if (result) {
-            done(result === module.exports.NULL ? null : result);
+          if (result !== undefined) {
+            done(result);
           }
         };
       });
     } else {
       options.importer = function(file, prev, bridge) {
-        function done(data) {
-          bridge.success(data);
+        function done(result) {
+          bridge.success(result === module.exports.NULL ? null : result);
         }
 
         var result = importer.call(options.context, file, prev, done);
 
-        if (result) {
-          done(result === module.exports.NULL ? null : result);
+        if (result !== undefined) {
+          done(result);
         }
       };
     }

--- a/test/api.js
+++ b/test/api.js
@@ -325,6 +325,17 @@ describe('api', function() {
       });
     });
 
+    it('should fallback to default import behaviour if importer returns sass.NULL', function(done) {
+      sass.render({
+        file: fixture('include-files/index.scss'),
+        importer: function(url, prev, done) {
+          done(sass.NULL);
+        }
+      }, function(error, result) {
+        assert.equal(result.css.toString().trim(), '/* foo.scss */\n/* bar.scss */');
+        done();
+      });
+    });
 
     it('should fallback to default import behaviour if importer returns null for backwards compatibility', function(done) {
       sass.render({
@@ -1010,7 +1021,7 @@ describe('api', function() {
             return sass.types.String('foo');
           },
           bar: function(a) {
-            assert.strictEqual(a, sass.NULL, 
+            assert.strictEqual(a, sass.NULL,
                 'Supplied value should be the same instance as sass.NULL');
 
             assert.throws(function() {


### PR DESCRIPTION
Whenever done() is called we should check for the sass.NULL
value as well.

While here, allow calling done(null) to anticipate
removal of the sass.NULL one day.

Closes https://github.com/sass/node-sass/pull/1308
Fixes https://github.com/sass/node-sass/issues/1296