### PR TITLE
Allow symlinked output directories

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -109,7 +109,7 @@ function isDirectory(filePath) {
   var isDir = false;
   try {
     var absolutePath = path.resolve(filePath);
-    isDir = fs.lstatSync(absolutePath).isDirectory();
+    isDir = fs.statSync(absolutePath).isDirectory();
   } catch (e) {
     isDir = e.code === 'ENOENT';
   }

--- a/test/cli.js
+++ b/test/cli.js
@@ -588,6 +588,24 @@ describe('cli', function() {
       });
     });
 
+    it('should not error if output directory is a symlink', function(done) {
+      var outputDir = fixture('input-directory/css');
+      var src = fixture('input-directory/sass');
+      var symlink = fixture('symlinked-css');
+      fs.mkdirSync(outputDir);
+      fs.symlinkSync(outputDir, symlink);
+      var bin = spawn(cli, [src, '--output', symlink]);
+
+      bin.once('close', function() {
+        var files = fs.readdirSync(outputDir).sort();
+        assert.deepEqual(files, ['one.css', 'two.css', 'nested'].sort());
+        var nestedFiles = fs.readdirSync(path.join(outputDir, 'nested'));
+        assert.deepEqual(nestedFiles, ['three.css']);
+        rimraf.sync(outputDir);
+        fs.unlinkSync(symlink);
+        done();
+      });
+    });
   });
 
   describe('node-sass in.scss --output path/to/file/out.css', function() {


### PR DESCRIPTION
Should fix the concern the user has in #1212 where using a symlinked output directory incorrectly errors out saying `An output directory must be specified when compiling a directory`
/cc @ysimonson