### PR TITLE
Accept process.execPath as-is

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -26,27 +26,6 @@ function collectArguments(args) {
 }
 
 /**
- * Get Runtime Info
- *
- * @api private
- */
-
-function getRuntimeInfo() {
-  var execPath = fs.realpathSync(process.execPath); // resolve symbolic link
-
-  var runtime = execPath
-               .split(/[\\/]+/).pop()
-               .split('.').shift();
-
-  runtime = runtime === 'nodejs' ? 'node' : runtime;
-
-  return {
-    name: runtime,
-    execPath: execPath
-  };
-}
-
-/**
  * Get binary name.
  * If environment variable SASS_BINARY_NAME,
  * .npmrc variable sass_binary_name or
@@ -122,7 +101,6 @@ var sass = process.sass = {};
 
 sass.binaryName = getBinaryName();
 sass.binaryUrl = getBinaryUrl();
-sass.runtime = getRuntimeInfo();
 
 /**
  * Get binary path.

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -135,9 +135,9 @@ function build(options) {
         return ['--', subject, '=', process.env[subject.toUpperCase()] || ''].join('');
       })).concat(options.args);
 
-    console.log(['Building:', process.sass.runtime.execPath].concat(args).join(' '));
+    console.log(['Building:', process.execPath].concat(args).join(' '));
 
-    var proc = spawn(process.sass.runtime.execPath, args, {
+    var proc = spawn(process.execPath, args, {
       stdio: [0, 1, 2]
     });
 


### PR DESCRIPTION
Remove red tape surrounding process.execPath
and use it as-is. In particular, do not try
to canonicalize the path returned by
process.execPath as this might be relative
in the restricted Linux environments
(for example using overlayfs).

We should be prepared to accept relative
or otherwise broken process.execPath and
have a faith it works (otherwise our
build scripts wouldn't be invoked
in the first place).

https://github.com/sass/node-sass/issues/1323