### PR TITLE
Publish debug file (PDB) of binding.node

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,15 @@
 
   build: off
 
+  clone_folder: c:\projects\node_modules\node-sass
+
+  # http://www.wintellect.com/devcenter/jrobbins/pdb-files-what-every-developer-must-know
+  # http://help.appveyor.com/discussions/kb/32-how-to-build-on-logical-drive-created-by-subst
+  init:
+    - cmd: >-
+        subst s: c:\projects
+    - ps: set-location -path s:\node_modules\node-sass
+
   cache:
     - '%userprofile%\.node-gyp'
     - '%AppData%\npm-cache'
@@ -41,15 +50,23 @@
   test_script: npm test
 
   before_deploy:
-    # Save artifact with full qualified names of binding.node
+    # Save artifacts with full qualified names of binding.node and binding.pdb
     # (which we use in node-sass-binaries repo)
-    - ps: Get-ChildItem .\vendor\**\*.node | % { Push-AppveyorArtifact $_.FullName -FileName (($_.FullName.Split('\\') | Select-Object -Last 2) -join '_') }
-
+    - ps: >-
+        Get-ChildItem .\vendor\**\*.node | % {
+           ( $BindingName = $_.FullName ).Split('\\') |
+             Select-Object -Last 2 | Select-Object -First 1 } |
+               .{ process { (
+                  @( $BindingName,
+                       ( ( $_, "binding.node" ) -join '_' ) ),
+                  @( ".\build\Release\binding.pdb", 
+                       ( ( $_, "binding.pdb" ) -join '_' ) )
+               ) } } | % { Push-AppveyorArtifact $_[0] -FileName $_[1] }
 
   deploy:
     - provider: GitHub
       description: $(APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED)
-      artifact: /.*binding\.node/           # upload all NuGet packages to release assets
+      artifact:
       auth_token:
         secure: tt+p58W9Q49faww/o0CODJI8e++YEX5THVlpXlRIigO4xHjE8NKigi0oxr1b2PJE
       on:
@@ -68,6 +85,13 @@
 
   build: off
 
+  clone_folder: c:\projects\node_modules\node-sass
+
+  init:
+    - cmd: >-
+        subst s: c:\projects
+    - ps: set-location -path s:\node_modules\node-sass
+
   cache:
     - '%userprofile%\.node-gyp'
     - '%AppData%\npm-cache'
@@ -81,6 +105,7 @@
       - nodejs_version: 2
       - nodejs_version: 3
       - nodejs_version: 4
+      - nodejs_version: 5
 
   install:
     - ps: Install-Product node $env:nodejs_version $env:platform

--- a/binding.gyp
+++ b/binding.gyp
@@ -19,6 +19,11 @@
         'src/sass_types/number.cpp',
         'src/sass_types/string.cpp'
       ],
+      'msvs_settings': {
+        'VCLinkerTool': {
+           'SetChecksum': 'true'
+        }
+      },
       'include_dirs': [
         '<!(node -e "require(\'nan\')")',
       ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -24,6 +24,14 @@
            'SetChecksum': 'true'
         }
       },
+      'xcode_settings': {
+        'OTHER_CPLUSPLUSFLAGS': [
+          '-std=c++11'
+        ],
+        'OTHER_LDFLAGS': [],
+        'GCC_ENABLE_CPP_EXCEPTIONS': 'NO',
+        'MACOSX_DEPLOYMENT_TARGET': '10.7'
+      },
       'include_dirs': [
         '<!(node -e "require(\'nan\')")',
       ],
@@ -57,16 +65,6 @@
             'libraries': [
               '<(libsass_library)',
             ],
-          }
-        }],
-        ['OS=="mac"', {
-          'xcode_settings': {
-            'OTHER_CPLUSPLUSFLAGS': [
-              '-std=c++11'
-            ],
-            'OTHER_LDFLAGS': [],
-            'GCC_ENABLE_CPP_EXCEPTIONS': 'NO',
-            'MACOSX_DEPLOYMENT_TARGET': '10.7'
           }
         }],
         ['OS=="win" and MSVS_VERSION == "2015"', {


### PR DESCRIPTION
To ensure proper debugging of problems of Windows,
publish PDB debug file along with the binary.

In order to keep paths to the source files clean apply
the technique described by John Robbins in
"PDB Files: what every developer must know"
http://www.wintellect.com/devcenter/jrobbins/pdb-files-what-every-developer-must-know
and build node-sass in the "S:\node_modules\node-sass"

During debugging, source files can be referenced
via the virtual "S:" drive.

This allows users and developers to assign S: drive to the project
root ("node_modules") and access source files without having to redefine
source paths.

Artifact names are generated in a nice, Lisp-styled functional PowerShell
hidden in a YAML folded scalar!

Add node 5 to the PR testing build.