### PR TITLE
Add bugs url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "libsass": "3.3.3",
   "description": "Wrapper around libsass",
   "license": "MIT",
+  "bugs": "https://github.com/sass/node-sass/issues",
   "homepage": "https://github.com/sass/node-sass",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Maintainers get a lot of emails about errors from users whom we inevitably have to direct to the issue tracker.

I suspect this is because, when an error happens, users are encouraged to run either `npm bugs` or `npm owner ls`.

`npm bugs` would fail without a bugs url, so they'll move onto `npm owner ls` and subsequently email us.

By adding the `bugs` url to the package.json, _hopefully_ this will mitigate some of the emails the maintainers receive.