### PR TITLE
Custom importers cause out of order chained imports.

### DIFF
--- a/test/api.js
+++ b/test/api.js
@@ -186,6 +186,29 @@ describe('api', function() {
   describe('.render(importer)', function() {
     var src = read(fixture('include-files/index.scss'), 'utf8');
 
+    it('should respect the order of chained imports when using custom importers and one file is custom imported and the other is not.', function(done) {
+      sass.render({
+        file: fixture('include-files/chained-imports-with-custom-importer.scss'),
+        importer: function(url, prev, done) {
+          if (url !== 'file-processed-by-loader') {
+            return sass.NULL;
+          }
+          done({
+            file: fixture('include-files/file-processed-by-loader.scss')
+          });
+        }
+      }, function(err, data) {
+        assert.equal(err, null);
+
+        assert.equal(
+          data.css.toString().trim(),
+          'body {\n  color: "red"; }'
+        );
+
+        done();
+      });
+    });
+
     it('should still call the next importer with the resolved prev path when the previous importer returned both a file and contents property - issue #1219', function(done) {
       sass.render({
         data: '@import "a";',

--- a/test/api.js
+++ b/test/api.js
@@ -190,11 +190,22 @@ describe('api', function() {
       sass.render({
         file: fixture('include-files/chained-imports-with-custom-importer.scss'),
         importer: function(url, prev, done) {
+          // NOTE: to see that this test failure is only due to the stated
+          // issue do each of the following and see that the tests pass.
+          //
+          //   a) add `return sass.NULL;` as the first line in this function to
+          //      cause non-custom importers to always be used.
+          //   b) comment out the conditional below to force our custom
+          //      importer to always be used.
+          //
+          //  You will notice that the tests pass when either all native, or
+          //  all custom importers are used, but not when a native + custom
+          //  import chain is used.
           if (url !== 'file-processed-by-loader') {
             return sass.NULL;
           }
           done({
-            file: fixture('include-files/file-processed-by-loader.scss')
+            file: fixture('include-files/' + url + '.scss')
           });
         }
       }, function(err, data) {

--- a/test/fixtures/include-files/chained-imports-with-custom-importer.scss
+++ b/test/fixtures/include-files/chained-imports-with-custom-importer.scss
@@ -1,0 +1,1 @@
+@import "file-not-processed-by-loader", "file-processed-by-loader";

--- a/test/fixtures/include-files/file-not-processed-by-loader.scss
+++ b/test/fixtures/include-files/file-not-processed-by-loader.scss
@@ -1,0 +1,1 @@
+$variable-defined-by-file-not-processed-by-loader: 'red';

--- a/test/fixtures/include-files/file-processed-by-loader.scss
+++ b/test/fixtures/include-files/file-processed-by-loader.scss
@@ -1,0 +1,3 @@
+body {
+  color: $variable-defined-by-file-not-processed-by-loader;
+}


### PR DESCRIPTION
I added a failing test case to demonstrate a bug in the current `importers`.

This error appears when you have custom `importers` defined, when a file has a chained import where the first import references a file not handled by the custom importer, and the second import is handled by the custom importer, the import order is broken.