### PR TITLE
Remove vendor directory on prepublish and pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,14 +32,16 @@
     "postinstall": "node scripts/build.js",
     "pretest": "node_modules/.bin/jshint bin lib scripts test",
     "test": "node_modules/.bin/mocha test",
-    "build": "node scripts/build.js --force"
+    "build": "node scripts/build.js --force",
+    "prepublish": "not-in-install && node scripts/prepublish.js || in-install"
   },
   "files": [
     "bin",
     "binding.gyp",
     "lib",
     "scripts",
-    "src"
+    "src",
+    "vendor"
   ],
   "keywords": [
     "css",
@@ -57,6 +59,7 @@
     "get-stdin": "^4.0.1",
     "glob": "^6.0.2",
     "got": "^5.4.1",
+    "in-publish": "^2.0.0",
     "meow": "^3.3.0",
     "mkdirp": "^0.5.1",
     "nan": "^2.0.8",

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -1,0 +1,17 @@
+/*!
+ * node-sass: scripts/install.js
+ */
+
+var path = require('path'),
+    rimraf = require('rimraf');
+
+function prepublish() {
+  var vendorPath = path.resolve(__dirname, '..', 'vendor');
+  rimraf.sync(vendorPath);
+}
+
+/**
+ * Run
+ */
+
+prepublish();


### PR DESCRIPTION
This is necessary because if a user is bundling node-sass in their
package, the vendor directory should stay so that the user isn't
required to run 'npm rebuild' afterwards, assuming that it was
originally installed on a like-architecture.
However, at the same time, when publishing, we don't want to include the
binaries since they may not work for a user plus there's the build step
that tries to download the correct binary for the current architecture.
Unfortunately, npm's prepublish hook runs on both prepublish *and* npm
install (see npm/npm#10074), so, using in-publish as a workaround to get
the prepublish script to only run prepublish and pack but not on
install.
This fixes #1183.