### PR TITLE
invoke custom functions with options.context

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -343,7 +343,7 @@ module.exports.render = function(options, cb) {
           bridge.success(data);
         }
 
-        var result = tryCallback(cb.callback, args.concat(done));
+        var result = tryCallback(cb.callback.bind(options.context), args.concat(done));
 
         if (result) {
           done(result);
@@ -400,7 +400,7 @@ module.exports.renderSync = function(options) {
       var cb = normalizeFunctionSignature(signature, functions[signature]);
 
       options.functions[cb.signature] = function() {
-        return tryCallback(cb.callback, arguments);
+        return tryCallback(cb.callback.bind(options.context), arguments);
       };
     });
   }

--- a/test/api.js
+++ b/test/api.js
@@ -857,6 +857,28 @@ describe('api', function() {
       });
     });
 
+    it('should call custom functions with correct context', function(done) {
+      function assertExpected(result) {
+        assert.equal(result.css.toString().trim(), 'div {\n  foo1: 1;\n  foo2: 2; }');
+      }
+      var options = {
+        data: 'div { foo1: foo(); foo2: foo(); }',
+        functions: {
+          // foo() is stateful and will persist an incrementing counter
+          'foo()': function() {
+            assert(this);
+            this.fooCounter = (this.fooCounter || 0) + 1;
+            return new sass.types.Number(this.fooCounter);
+          }
+        }
+      };
+
+      sass.render(options, function(error, result) {
+        assertExpected(result);
+        done();
+      });
+    });
+
     describe('should properly bubble up errors from sass color constructor', function() {
       it('four booleans', function(done) {
         sass.render({
@@ -1590,6 +1612,25 @@ describe('api', function() {
         });
       }, /Supplied value should be a string/);
 
+      done();
+    });
+
+    it('should call custom functions with correct context', function(done) {
+      function assertExpected(result) {
+        assert.equal(result.css.toString().trim(), 'div {\n  foo1: 1;\n  foo2: 2; }');
+      }
+      var options = {
+        data: 'div { foo1: foo(); foo2: foo(); }',
+        functions: {
+          // foo() is stateful and will persist an incrementing counter
+          'foo()': function() {
+            assert(this);
+            this.fooCounter = (this.fooCounter || 0) + 1;
+            return new sass.types.Number(this.fooCounter);
+          }
+        }
+      };
+      assertExpected(sass.renderSync(options));
       done();
     });
   });


### PR DESCRIPTION
This allows custom functions to execute against the current render context. This is similar to the [current behavior of importers](https://github.com/sass/node-sass/blob/99dc18c448fcbb53b9e38d52eada3b39b3a57337/lib/index.js#L321).

This was discussed briefly in https://github.com/sass/node-sass/pull/783#discussion_r26910939

The benefit of this is that custom functions can persist data (be stateful), for the lifespan of the render.

This would allow you to do something like...

```js
{
  ...,
  functions: {
    "register-foo($foo)": function($foo) {
      this.myNamespace.$foo = $foo;
      ...
    },
    "get-foo()": function() {
      return this.myNamespace.$foo;
    }
  }
}
```
This would help alleviate some of the perf overhead we've seen with #1198. In our case, we currently store all stateful things in Sass variables and have to pass them around whenever we need them in JS.

NOTE: this is potentially a "breaking" change if anyone is currently using functions with an implicitly bound context.
```js
function Foo() {
  this.data;
}
Foo.prototype.doSomething = function() {
  return this.data;
};
var foo = new Foo();
{
  functions: {
    "doSomething()": foo.doSomething
  }
}
```
This would break as we are now binding `doSomething` to `options.context`, rather than `foo`.

The fix on the consumer side would be to explicitly bind to the context they need:
```js
{
  functions: {
    "doSomething": foo.doSomething.bind(foo)
  }
}
```