### PR TITLE
Add an Issue template to help triage the backlog

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Reporting an installation issue
+1. I'm running on a [supported platform](https://github.com/sass/node-sass-binaries/blob/master/README.md#compatibility)
+1. Have you recently installed a new version of Node? Native bindings are downloading for the specific version of Node when you install `node-sass`. Delete your `node_modules` and then re-install.
+1. Create [Gist](https://gist.github.com/) with the npm.log file and add it to this issue
+1. I've [searched for existing issues](https://github.com/sass/node-sass/search?type=Issues)
+1. I've followed the [Troubleshooting Guide](TROUBLESHOOTING.md)
+
+## My Sass isn't compiling
+1. My code compiles on [SassMeister](http://www.sassmeister.com/) when using the Ruby Sass complier
+1. Try the Beta version of `node-sass` to see if the latest `libsass` fixes this
+1. Create a reproducible sample, and [open an issue on `libsass`](https://github.com/sass/libsass/issues/new). Compiler issues need to be fixed there, not here.


### PR DESCRIPTION
Taking a kick at https://help.github.com/articles/creating-an-issue-template-for-your-repository/
It might make sense to merge some of the Troubleshooting/Contributing content directly here later.
The "supported platforms" I linked to is out of date and may not be useful as-is.

PS: This could also get moved to a `.github` folder in the root to keep it cleaner.
