### PR TITLE
Drop iojs from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ env:
   matrix:
     - export NODE_VERSION="0.10"
     - export NODE_VERSION="0.12"
-    - export NODE_VERSION="iojs-v1.0"
-    - export NODE_VERSION="iojs-v1"
-    - export NODE_VERSION="iojs-v2"
-    - export NODE_VERSION="iojs-v3"
     - export NODE_VERSION="4"
     - export NODE_VERSION="5"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -101,9 +101,6 @@
     matrix:
       - nodejs_version: 0.10
       - nodejs_version: 0.12
-      - nodejs_version: 1
-      - nodejs_version: 2
-      - nodejs_version: 3
       - nodejs_version: 4
       - nodejs_version: 5
 


### PR DESCRIPTION
This PR does not mean we are dropping support for iojs. We're
simply not building it in CI. There are no new versions being
released for iojs and usage is [extremely low][0]. Since we're still
building iojs binaries for releases we don't risking breaking
support.

[0]: https://twitter.com/seldo/status/712386414902521861