### PR TITLE
Update custom importer documentation to advocate returning `null`

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Starting from v3.0.0:
   return new Error('nothing to do here');
   ```
 
-* importer can be an array of functions, which will be called by LibSass in the order of their occurrence in array. This helps user specify special importer for particular kind of path (filesystem, http). If an importer does not want to handle a particular path, it should return `sass.NULL`. See [functions section](#functions--v300) for more details on Sass types.
+* importer can be an array of functions, which will be called by LibSass in the order of their occurrence in array. This helps user specify special importer for particular kind of path (filesystem, http). If an importer does not want to handle a particular path, it should return `null`. See [functions section](#functions--v300) for more details on Sass types.
 
 ### functions (>= v3.0.0) - _experimental_
 


### PR DESCRIPTION
With #1291 custom importers can now return `null` instead of
`sass.NULL`. This means custom importer modules no longer need to
have node-sass as a dependency.