### PR TITLE
Ouptut a deprecation warning to stdout when using process.sass

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -441,10 +441,14 @@ module.exports.NULL = binding.types.Null.NULL;
  * TODO: remove for 4.0
  */
 
+function processSassDeprecationMessage() {
+  console.log('Deprecation warning: `process.sass` is an undocumented internal that will be removed in future versions of Node Sass.');
+}
+
 process.sass = process.sass || {
-  versionInfo: module.exports.info,
-  binaryName: sass.getBinaryName(),
-  binaryUrl: sass.getBinaryUrl(),
-  binaryPath: sass.getBinaryPath(),
-  getBinaryPath: sass.getBinaryPath,
+  get versionInfo()   { processSassDeprecationMessage(); return module.exports.info; },
+  get binaryName()    { processSassDeprecationMessage(); return sass.getBinaryName(); },
+  get binaryUrl()     { processSassDeprecationMessage(); return sass.getBinaryUrl(); },
+  get binaryPath()    { processSassDeprecationMessage(); return sass.getBinaryPath(); },
+  get getBinaryPath() { processSassDeprecationMessage(); return sass.getBinaryPath; },
 };


### PR DESCRIPTION
This is an undocumented internal API that will be removed. Access
`process.sass` will produce the following warning.

>Deprecation warning: `process.sass` is an undocumented internal
that will be removed in future versions of Node Sass.

Continuation of #1427.