### PR TITLE
Fix a regression in binary verification

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -167,7 +167,6 @@ function getBinaryUrl() {
  * callers wants to throw if file not exists before
  * returning.
  *
- * @param {Boolean} throwIfNotExists
  * @api public
  */
 
@@ -188,6 +187,13 @@ function getBinaryPath() {
 
   return binaryPath;
 }
+
+/**
+ * Does the supplied binary path exist
+ *
+ * @param {String} binaryPath
+ * @api public
+ */
 
 function hasBinary(binaryPath) {
   return fs.existsSync(binaryPath);

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -81,7 +81,7 @@ function applyProxy(options, cb) {
  */
 
 function checkAndDownloadBinary() {
-  if (sass.getBinaryPath()) {
+  if (sass.hasBinary(sass.getBinaryPath())) {
     return;
   }
 
@@ -97,7 +97,7 @@ function checkAndDownloadBinary() {
         return;
       }
 
-      console.log('Binary downloaded and installed at', sass.binaryPath());
+      console.log('Binary downloaded and installed at', sass.getBinaryPath());
     });
   });
 }


### PR DESCRIPTION
A regression introduced in 22c560c7 broke binary verification
causing the binary to always be built locally.

Fixes #1434