### PR TITLE
Add friendly name for the Node 6 release and fallback

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -37,6 +37,7 @@ function getHumanNodeVersion(arg) {
     case 45: return 'io.js 3.x';
     case 46: return 'Node.js 4.x';
     case 47: return 'Node.js 5.x';
+    case 48: return 'Node.js 6.x';
     default: return false;
   }
 }
@@ -52,7 +53,9 @@ function getHumanEnvironment(env) {
     getHumanPlatform(parts[0]),
     getHumanArchitecture(parts[1]),
     'with',
-    getHumanNodeVersion(parts[2]),
+    getHumanNodeVersion(parts[2]) !== false ?
+    getHumanNodeVersion(parts[2]) :
+    'Unknown or unsupported Node process.versions.modules version "' + parts[2] + '"',
   ].join(' ');
 }
 


### PR DESCRIPTION
Noticed that the message when the binding module version is unknown it currently says "if false"
Not sure how to to test this properly, I just eyeballed the patch in the IDE.