### PR TITLE
Replace TODO URL with release tab for supported versions

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -2,7 +2,8 @@
  * node-sass: lib/errors.js
  */
 
-var sass = require('./extensions');
+var sass = require('./extensions'),
+    pkg = require('../package.json');
 
 function humanEnvironment() {
   return sass.getHumanEnvironment(sass.getBinaryName());
@@ -32,7 +33,7 @@ module.exports.unsupportedEnvironment = function() {
   return [
     'Node Sass does not yet support your current environment: ' + humanEnvironment(),
     'For more information on which environments are supported please see:',
-    'TODO URL'
+    'https://github.com/sass/node-sass/releases/tag/v' + pkg.version
   ].join('\n');
 };
 

--- a/test/errors.js
+++ b/test/errors.js
@@ -34,7 +34,7 @@ describe('binary errors', function() {
 
     it('links to supported environment documentation', function() {
       var message = errors.unsupportedEnvironment();
-      assert.ok(message.indexOf('TODO URL') !== -1);
+      assert.ok(message.indexOf('https://github.com/sass/node-sass/releases/tag/v') !== -1);
     });
   });
 


### PR DESCRIPTION
This would assume that a quick version table gets added to the release page after attaching the bindings during the release. EX:

OS | Node
------------ | -------------
Windows x86 & x64 | 0.10, 0.12, 1, 2, 3, 4, 5
OSX x64 | 0.10, 0.12, 1, 2, 3, 4, 5
Linux x86 & x64 | 0.10, 0.12, 1, 2, 3, 4, 5