### PR TITLE
Improve error message for unsupported environments

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -42,17 +42,30 @@ function getHumanNodeVersion(arg) {
 }
 
 function getHumanEnvironment(env) {
-  var parts = env.replace(/_binding\.node$/, '').split('-');
+  var binding = env.replace(/_binding\.node$/, ''),
+      parts = binding.split('-'),
+      platform = getHumanPlatform(parts[0]),
+      arch = getHumanArchitecture(parts[1]),
+      runtime = getHumanNodeVersion(parts[2]);
 
   if (parts.length !== 3) {
-    return 'Unknown environment';
+    return 'Unknown environment (' + binding + ')';
+  }
+
+  if (!platform) {
+    platform = 'Unsupported platform (' + parts[0] + ')';
+  }
+
+  if (!arch) {
+    arch = 'Unsupported architecture (' + parts[1] + ')';
+  }
+
+  if (!runtime) {
+    runtime = 'Unsupported runtime (' + parts[2] + ')';
   }
 
   return [
-    getHumanPlatform(parts[0]),
-    getHumanArchitecture(parts[1]),
-    'with',
-    getHumanNodeVersion(parts[2]),
+    platform, arch, 'with', runtime,
   ].join(' ');
 }
 
@@ -60,11 +73,11 @@ function getInstalledBinaries() {
   return fs.readdirSync(defaultBinaryPath);
 }
 
-function isSupportedEnvironment() {
+function isSupportedEnvironment(platform, arch, runtime) {
   return (
-    false !== getHumanPlatform() &&
-    false !== getHumanArchitecture() &&
-    false !== getHumanNodeVersion()
+    false !== getHumanPlatform(platform) &&
+    false !== getHumanArchitecture(arch) &&
+    false !== getHumanNodeVersion(runtime)
   );
 }
 

--- a/test/api.js
+++ b/test/api.js
@@ -1829,49 +1829,94 @@ describe('api', function() {
     });
 
     describe('on unsupported environment', function() {
-      it('should error for unsupported architecture', function() {
-        var prevValue = process.arch;
+      describe('with an unsupported architecture', function() {
+        var prevValue;
 
-        Object.defineProperty(process, 'arch', {
-          get: function () { return 'foo'; }
+        beforeEach(function() {
+          prevValue = process.arch;
+
+          Object.defineProperty(process, 'arch', {
+            get: function () { return 'foo'; }
+          });
         });
 
-        assert.throws(
-          function() { require(sassPath); },
-          'Node Sass does not yet support your current environment'
-        );
+        afterEach(function() {
+          process.arch = prevValue;
+        });
 
-        process.arch = prevValue;
+        it('should error', function() {
+          assert.throws(
+            function() { require(sassPath); },
+            'Node Sass does not yet support your current environment'
+          );
+        });
+
+        it('should inform the user the architecture is unsupported', function() {
+          assert.throws(
+            function() { require(sassPath); },
+            'Unsupported architecture (foo)'
+          );
+        });
       });
 
-      it('should error for unsupported platform', function() {
-        var prevValue = process.platform;
+      describe.only('with an unsupported platform', function() {
+        var prevValue;
 
-        Object.defineProperty(process, 'platform', {
-          get: function () { return 'foo'; }
+        beforeEach(function() {
+          prevValue = process.platform;
+
+          Object.defineProperty(process, 'platform', {
+            get: function () { return 'bar'; }
+          });
         });
 
-        assert.throws(
-          function() { require(sassPath); },
-          'Node Sass does not yet support your current environment'
-        );
+        afterEach(function() {
+          process.platform = prevValue;
+        });
 
-        process.platform = prevValue;
+        it('should error', function() {
+          assert.throws(
+            function() { require(sassPath); },
+            'Node Sass does not yet support your current environment'
+          );
+        });
+
+        it('should inform the user the platform is unsupported', function() {
+          assert.throws(
+            function() { require(sassPath); },
+            'Unsupported platform (bar)'
+          );
+        });
       });
 
-      it('should error for unsupported runtime', function() {
-        var prevValue = process.versions.modules;
+      describe('with an unsupported platform', function() {
+        var prevValue;
 
-        Object.defineProperty(process.versions, 'modules', {
-          get: function () { return 'foo'; }
+        beforeEach(function() {
+          prevValue = process.versions.modules;
+
+          Object.defineProperty(process.versions, 'modules', {
+            get: function () { return 'baz'; }
+          });
         });
 
-        assert.throws(
-          function() { require(sassPath); },
-          'Node Sass does not yet support your current environment'
-        );
+        afterEach(function() {
+          process.versions.modules = prevValue;
+        });
 
-        process.versions.modules = prevValue;
+        it('should error', function() {
+          assert.throws(
+            function() { require(sassPath); },
+            'Node Sass does not yet support your current environment'
+          );
+        });
+
+        it('should inform the user the runtime is unsupported', function() {
+          assert.throws(
+            function() { require(sassPath); },
+            'Unsupported runtime (baz)'
+          );
+        });
       });
     });
   });


### PR DESCRIPTION
The human friendly name for an unknown platform, arch or runtime
is currently `false`. With this patch the user is better informed
as to why their environment is unsupported. The raw value is also
output to ease with bug reports.

Closes #1487