### PR TITLE
Attempt to fix AppVeyor tag race condition

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -79,6 +79,13 @@
         appveyor_repo_tag: true       # deploy on tag push only
 
 -
+  branches:
+    except:
+      - release
+      - /v\d\.\d\.\d/
+
+  skip_tags: true
+
   os: Visual Studio 2013
 
   configuration: testing


### PR DESCRIPTION
Currently it's a bit of an ordeal trying to get the atomic puush
required for AppVeyor to register a commit on the release branch
and also a tag. Looks like AppVeyor expects you to do release from
the master branch.

Inspired by @nschonni work in #1518 in an attempt to work around
this issue this PR instructs AppVeyor to ignore tags on non-release
branches.

Fingers crossed this makes like easier.

Closes #1518