### PR TITLE
Don't run tests when building a Windows release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,9 +51,7 @@
     - git submodule update --init --recursive
     - npm install --msvs_version=2013
 
-  test_script:
-    - ps: set-location -path c:\projects\node_modules\node-sass
-    - npm test
+  test: off
 
   before_deploy:
     # Save artifacts with full qualified names of binding.node and binding.pdb


### PR DESCRIPTION
This slows down the release builds and in the worst case scenario
causes a single job failing meaning we need to rerun the entire build.

Problems with tests will have been caught we'll before we start
building release binaries.

Thoughts @saper?