### PR TITLE
Add cache for downloaded binary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.log
+.idea
 .DS_Store
 .sass-cache
 build

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "async-foreach": "^0.1.3",
     "chalk": "^1.1.1",
     "cross-spawn-async": "^2.1.9",
+    "fs-extra": "^0.30.0",
     "gaze": "^1.0.0",
     "get-stdin": "^4.0.1",
     "glob": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "mkdirp": "^0.5.1",
     "nan": "^2.3.2",
     "node-gyp": "^3.3.1",
+    "os-tmpdir": "^1.0.1",
     "request": "^2.61.0",
     "sass-graph": "^2.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "async-foreach": "^0.1.3",
     "chalk": "^1.1.1",
     "cross-spawn-async": "^2.1.9",
-    "fs-extra": "^0.30.0",
     "gaze": "^1.0.0",
     "get-stdin": "^4.0.1",
     "glob": "^7.0.3",

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -142,7 +142,7 @@ function getTempPath(binaryName) {
   ];
 
   for (var i = 0; i < candidateTmpDirs.length; i++) {
-    var candidatePath = path.join(candidateTmpDirs[i], 'node-sass', "v" + pkg.version);
+    var candidatePath = path.join(candidateTmpDirs[i], 'node-sass', 'releases', 'download', 'v' + pkg.version);
 
     try {
       mkdir.sync(candidatePath);

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -142,7 +142,7 @@ function getTempPath(binaryName) {
   ];
 
   for (var i = 0; i < candidateTmpDirs.length; i++) {
-    var candidatePath = path.join(candidateTmpDirs[i], 'node-sass');
+    var candidatePath = path.join(candidateTmpDirs[i], 'node-sass', "v" + pkg.version);
 
     try {
       mkdir.sync(candidatePath);

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -3,7 +3,6 @@
  */
 
 var fs = require('fs'),
-    fsextra = require('fs-extra'),
     eol = require('os').EOL,
     mkdir = require('mkdirp'),
     path = require('path'),
@@ -146,7 +145,7 @@ function getTempPath(binaryName) {
     var candidatePath = path.join(candidateTmpDirs[i], 'node-sass');
 
     try {
-      fsextra.mkdirsSync(candidatePath, '0777');
+      mkdir.sync(candidatePath);
       return path.join(candidatePath, binaryName);
     } catch (err) {
       console.error(candidatePath, 'is not writable:', err.message);


### PR DESCRIPTION
- The binary file is downloaded to a tmp folder and copied to vendor destination. If the binary already exist in the tmp folder, it will be copied only.
- With this change node-sass will work offline, cache the binary and save bandwidth.
- The binary configuration parameters will work the same as before.

Fixes #1554.