### PR TITLE
In watch mode, play an audible cue when there is an error.

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -143,8 +143,11 @@ function getEmitter() {
   var emitter = new Emitter();
 
   emitter.on('error', function(err) {
-    console.error(err);
-    if (!options.watch) {
+    if (options.watch) {
+      // add the bell character, to make an audible noise
+      console.error(err + '\x07');
+    } else {
+      console.error(err);
       process.exit(1);
     }
   });


### PR DESCRIPTION
This adds a feature I like from the CoffeeScript compiler - when in watch mode, make an audible noise if there is an error processing a watched file.