### PR TITLE
Revert "Node 6 with AppVeyor: don't use subst for testing (#1514)"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,7 @@
   environment:
     SKIP_SASS_BINARY_DOWNLOAD_FOR_CI: true
     matrix:
+      - nodejs_version: 6
       - nodejs_version: 0.10
       - nodejs_version: 0.12
       - nodejs_version: 1.0
@@ -42,7 +43,6 @@
       - nodejs_version: 3
       - nodejs_version: 4
       - nodejs_version: 5
-      - nodejs_version: 6
 
   install:
     - ps: Install-Product node $env:nodejs_version $env:platform
@@ -51,9 +51,7 @@
     - git submodule update --init --recursive
     - npm install --msvs_version=2013
 
-  test_script:
-    - ps: set-location -path c:\projects\node_modules\node-sass
-    - npm test
+  test_script: npm test
 
   before_deploy:
     # Save artifacts with full qualified names of binding.node and binding.pdb
@@ -111,11 +109,11 @@
   environment:
     SKIP_SASS_BINARY_DOWNLOAD_FOR_CI: true
     matrix:
+      - nodejs_version: 6
       - nodejs_version: 0.10
       - nodejs_version: 0.12
       - nodejs_version: 4
       - nodejs_version: 5
-      - nodejs_version: 6
 
   install:
     - ps: Install-Product node $env:nodejs_version $env:platform
@@ -124,6 +122,4 @@
     - git submodule update --init --recursive
     - npm install --msvs_version=2013
 
-  test_script:
-    - ps: set-location -path c:\projects\node_modules\node-sass
-    - npm test
+  test_script: npm test


### PR DESCRIPTION
This reverts commit 15fe42e to assert nodejs/node#6500 is resolved in Node v6.2.0.