### PR TITLE
add eyeglass cli option

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -56,11 +56,13 @@ var cli = meow({
     '  --error-bell               Output a bell character on errors',
     '  --importer                 Path to .js file containing custom importer',
     '  --functions                Path to .js file containing custom functions',
+    '  --eyeglass                 Use eyeglass (requires that eyeglass is installed)',
     '  --help                     Print usage info'
   ].join('\n')
 }, {
   boolean: [
     'error-bell',
+    'eyeglass',
     'follow',
     'indented-syntax',
     'omit-source-map-url',
@@ -223,6 +225,11 @@ function getOptions(args, options) {
     }
   }
 
+  if (options.eyeglass) {
+    var eyeglass = require("eyeglass");
+    options = eyeglass(options);
+  }
+
   return options;
 }
 
@@ -309,7 +316,7 @@ function run(options, emitter) {
     emitter.emit('error', 'The --source-map option must be either a boolean or directory when compiling a directory');
   }
 
-  if (options.importer) {
+  if (options.importer && typeof options.importer === 'string') {
     if ((path.resolve(options.importer) === path.normalize(options.importer).replace(/(.+)([\/|\\])$/, '$1'))) {
       options.importer = require(options.importer);
     } else {
@@ -317,7 +324,7 @@ function run(options, emitter) {
     }
   }
 
-  if (options.functions) {
+  if (options.functions && typeof options.functions === 'string') {
     if ((path.resolve(options.functions) === path.normalize(options.functions).replace(/(.+)([\/|\\])$/, '$1'))) {
       options.functions = require(options.functions);
     } else {


### PR DESCRIPTION
It is still quite confusing how to use eyeglass, and I guess part of the problem is that it is not supported by the node-sass cli.

You might argue that this does not belong here. I had first tried to create an eyeglass cli that would mirror node-sass. But that would be a lot of code duplication. The best argument against including this would be if there were other libraries like eyeglass. Obviously we can not add options for all of them. But as far as I know, there is only this one.