### PR TITLE
`process.config.target_defaults` not available on some platforms (electron)

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -19,9 +19,10 @@ var eol = require('os').EOL,
 
 function afterBuild(options) {
   var install = sass.getBinaryPath();
-  var target = path.join(__dirname, '..', 'build',
-    options.debug ? 'Debug' : process.config.target_defaults.default_configuration,
-    'binding.node');
+  var targetDefaults = process.config.target_defaults;
+  var defaultConfig = targetDefaults ? targetDefaults.default_configuration : 'Release';
+  var targetConfig = options.debug ? 'Debug' : defaultConfig;
+  var target = path.join(__dirname, '..', 'build', targetConfig, 'binding.node');
 
   mkdir(path.dirname(install), function(err) {
     if (err && err.code !== 'EEXIST') {


### PR DESCRIPTION
`process.config.target_defaults` is required for building node-sass but it is not available on Electron so fallback to using 'Release' when undefined.

re: https://github.com/electron/electron/issues/6462