### PR TITLE
process.config may be empty (electron)

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -20,7 +20,10 @@ var eol = require('os').EOL,
 function afterBuild(options) {
   var install = sass.getBinaryPath();
   var target = path.join(__dirname, '..', 'build',
-    options.debug ? 'Debug' : process.config.target_defaults.default_configuration,
+    options.debug ? 'Debug' :
+        process.config.target_defaults
+            ?  process.config.target_defaults.default_configuration
+            : 'Release',
     'binding.node');
 
   mkdir(path.dirname(install), function(err) {


### PR DESCRIPTION
Fixes: https://github.com/sass/node-sass/pull/1631
Fixes: https://github.com/electron/electron/issues/6462
Broken-By: https://github.com/sass/node-sass/pull/1101
Fix-Provided-By: https://github.com/sass/node-sass/pull/1631