### PR TITLE
add "flatten" to cli in order to output a flat directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,7 @@ Example:
     -o, --output               Output directory
     -x, --omit-source-map-url  Omit source map URL comment from output
     -i, --indented-syntax      Treat data from stdin as sass code (versus scss)
+    -f, --flatten              Flattens the output directory
     -q, --quiet                Suppress log output except on error
     -v, --version              Prints version info
     --output-style             CSS output style (nested | expanded | compact | compressed)

--- a/bin/node-sass
+++ b/bin/node-sass
@@ -41,6 +41,7 @@ var cli = meow({
     '  -i, --indented-syntax      Treat data from stdin as sass code (versus scss)',
     '  -q, --quiet                Suppress log output except on error',
     '  -v, --version              Prints version info',
+    '  -f, --flatten              Flattens output directory',
     '  --output-style             CSS output style (nested | expanded | compact | compressed)',
     '  --indent-type              Indent type for output CSS (space | tab)',
     '  --indent-width             Indent width; number of spaces or tabs (maximum value: 10)',
@@ -85,6 +86,7 @@ var cli = meow({
   alias: {
     c: 'source-comments',
     i: 'indented-syntax',
+    f: 'flatten',
     q: 'quiet',
     o: 'output',
     r: 'recursive',
@@ -96,6 +98,7 @@ var cli = meow({
     'include-path': process.cwd(),
     'indent-type': 'space',
     'indent-width': 2,
+    flatten: false,
     linefeed: 'lf',
     'output-style': 'nested',
     precision: 5,
@@ -196,7 +199,11 @@ function getOptions(args, options) {
     var sassDir = path.resolve(options.directory);
     var file = path.relative(sassDir, args[0]);
     var cssDir = path.resolve(options.output);
-    options.dest = path.join(cssDir, file).replace(path.extname(file), '.css');
+    if (options.flatten){
+      options.dest = path.join(cssDir, path.basename(file)).replace(path.extname(file), '.css');
+    } else {
+      options.dest = path.join(cssDir, file).replace(path.extname(file), '.css');
+    }
   }
 
   if (options.sourceMap) {

--- a/test/cli.js
+++ b/test/cli.js
@@ -564,6 +564,20 @@ describe('cli', function() {
         done();
       });
     });
+    
+    it('should be flattened output if --flatten true', function(done) {
+      var src = fixture('input-directory/sass');
+      var dest = fixture('input-directory/css');
+      var bin = spawn(cli, [src, '--output -', dest, '--flatten']);
+      
+      
+      bin.once('close', function() {
+        var files = fs.readdirSync(dest).sort();
+        assert.deepEqual(files, ['one.css', 'two.css', 'three.css'].sort());
+        rimraf.sync(dest);
+        done();
+      });
+    });
 
     it('should error if no output directory is provided', function(done) {
       var src = fixture('input-directory/sass');


### PR DESCRIPTION
- Add a flatten flag to the CLI `-f` or `-flatten` to output a flattened directory

So:
```
- scss/page.scss
- scss/page-types/page1.scss
```

will output to:

```
css/page.css
css/page1.css
```

I couldn't find a way to do this with the current CLI so I added this. Figured it may be useful for other people with nested directories of pages.