### PR TITLE
Add a nice little progress bar while downloading binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "mkdirp": "^0.5.1",
     "nan": "^2.3.2",
     "node-gyp": "^3.3.1",
+    "progress": "^1.1.8",
     "request": "^2.61.0",
     "sass-graph": "^2.1.1"
   },

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -44,7 +44,7 @@ function download(url, dest, cb) {
   };
 
   try {
-    console.log("Start downloading binary at", url);
+    console.log('Start downloading binary at', url);
     request(url, options, function(err, response) {
       if (err) {
         reportError(err);
@@ -63,7 +63,7 @@ function download(url, dest, cb) {
           complete: '=',
           incomplete: ' ',
           width: 25,
-          total: parseInt(response.headers["content-length"])
+          total: parseInt(response.headers['content-length'])
         });
 
         response.on('data', function(chunk) {

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -8,6 +8,7 @@ var fs = require('fs'),
     path = require('path'),
     sass = require('../lib/extensions'),
     request = require('request'),
+    ProgressBar = require('progress'),
     pkg = require('../package.json');
 
 /**
@@ -43,6 +44,7 @@ function download(url, dest, cb) {
   };
 
   try {
+    console.log("Start downloading binary at", url);
     request(url, options, function(err, response) {
       if (err) {
         reportError(err);
@@ -56,6 +58,17 @@ function download(url, dest, cb) {
         if (successful(response)) {
           response.pipe(fs.createWriteStream(dest));
         }
+
+        var bar = new ProgressBar('Total :total [:bar] :current :percent :etas', {
+          complete: '=',
+          incomplete: ' ',
+          width: 25,
+          total: parseInt(response.headers["content-length"])
+        });
+
+        response.on('data', function(chunk) {
+          bar.tick(chunk.length);
+        });
     });
   } catch (err) {
     cb(err);

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -63,7 +63,7 @@ function download(url, dest, cb) {
           complete: '=',
           incomplete: ' ',
           width: 25,
-          total: parseInt(response.headers['content-length'])
+          total: parseInt(response.headers['content-length'], 10)
         });
 
         response.on('data', function(chunk) {


### PR DESCRIPTION
I stuck for half a hour while installing node-sass as dependency of my project.
After read the source code, I figure out that my download speed from github.com is too slow. Then the problem solved by turning my VPN on.

So I decided to add a progress bar as a reminder, made life easier for people whose network connection is poor.

Downloading

        Start downloading binary at https://github.com/sass/node-sass/releases/download/v3.8.0/darwin-x64-48_binding.node
        Total 2602136 [===============          ] 1566256 60% 4.9s

Success

        Start downloading binary at https://github.com/sass/node-sass/releases/download/v3.8.0/darwin-x64-48_binding.node
        Total 2602136 [=========================] 2602136 100% 0.0s
        Binary downloaded and installed at /Users/skylarzheng/playground/node-sass/vendor/darwin-x64-48/binding.node