### PR TITLE
Build: Rename pretest to lint and only run once in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ script:
 
 after_success:
   - if [ $TRAVIS_OS_NAME == "linux" ] && [ $TRAVIS_NODE_VERSION == "4" ]; then
+      npm run lint;
       npm run-script coverage;
     fi
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "node scripts/coverage.js",
     "install": "node scripts/install.js",
     "postinstall": "node scripts/build.js",
-    "pretest": "node_modules/.bin/eslint bin/node-sass lib scripts test",
+    "lint": "node_modules/.bin/eslint bin/node-sass lib scripts test",
     "test": "node_modules/.bin/mocha test",
     "build": "node scripts/build.js --force",
     "prepublish": "not-in-install && node scripts/prepublish.js || in-install"


### PR DESCRIPTION
This allows us to bump beyond ESLint 2.x in the future since it dropped support for Node <4