### PR TITLE
Fix node vs nodejs discrepency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
   },
   "gypfile": true,
   "scripts": {
-    "coverage": "node scripts/coverage.js",
-    "install": "node scripts/install.js",
-    "postinstall": "node scripts/build.js",
-    "lint": "node_modules/.bin/eslint bin/node-sass lib scripts test",
-    "test": "node_modules/.bin/mocha test",
-    "build": "node scripts/build.js --force",
+    "coverage": "scripts/coverage.js",
+    "install": "scripts/install.js",
+    "postinstall": "scripts/build.js",
+    "lint": "eslint bin/node-sass lib scripts test",
+    "test": "mocha test",
+    "build": "scripts/build.js --force",
     "prepublish": "not-in-install && node scripts/prepublish.js || in-install"
   },
   "files": [


### PR DESCRIPTION
Some Ubuntu OSes install `node` as `nodejs`. This breaks our npm lifecycle scripts that explicitly executes `node`. Npm's documentation suggests that a `*.js` lifecycle script should be executed by npm itself (presumably using the correct node binary).