### PR TITLE
Test: Increase timeout for CLI tests

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -13,6 +13,8 @@ var assert = require('assert'),
 describe('cli', function() {
 
   before(function(done) {
+    // The CLI tests can be flakey on CI, so don't timeout for 10 minutes
+    this.timeout(600000);
     var bin = spawn(cli, ['-v']);
     bin.stdout.setEncoding('utf8');
     bin.stdout.once('data', function(data) {


### PR DESCRIPTION
They tend to bomb out from time to time on CI, so using the method
described here http://stackoverflow.com/a/15982893/455535 and the docs
http://mochajs.org/#test-level to increase the timeout from 2 seconds
to unlimited