### PR TITLE
Implement SASS_PATH

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,6 @@ if (!sass.hasBinary(sass.getBinaryPath())) {
   }
 }
 
-
 /**
  * Require binding
  */
@@ -165,6 +164,26 @@ function getLinefeed(options) {
 }
 
 /**
+ * Build an includePaths string
+ * from the options.includePaths array and the SASS_PATH environment variable
+ *
+ * @param {Object} options
+ * @api private
+ */
+
+function buildIncludePaths(options) {
+  options.includePaths = options.includePaths || [];
+
+  if (process.env.hasOwnProperty('SASS_PATH')) {
+    options.includePaths = options.includePaths.concat(
+      process.env.SASS_PATH.split(path.delimiter)
+    );
+  }
+
+  return options.includePaths.join(path.delimiter);
+}
+
+/**
  * Get options
  *
  * @param {Object} options
@@ -173,12 +192,13 @@ function getLinefeed(options) {
 
 function getOptions(opts, cb) {
   var options = clonedeep(opts || {});
+
   options.sourceComments = options.sourceComments || false;
   if (options.hasOwnProperty('file')) {
     options.file = getInputFile(options);
   }
   options.outFile = getOutputFile(options);
-  options.includePaths = (options.includePaths || []).join(path.delimiter);
+  options.includePaths = buildIncludePaths(options);
   options.precision = parseInt(options.precision) || 5;
   options.sourceMap = getSourceMap(options);
   options.style = getStyle(options);

--- a/test/fixtures/sass-path/expected-orange.css
+++ b/test/fixtures/sass-path/expected-orange.css
@@ -1,0 +1,3 @@
+body {
+  background: orange; }
+

--- a/test/fixtures/sass-path/expected-red.css
+++ b/test/fixtures/sass-path/expected-red.css
@@ -1,0 +1,3 @@
+body {
+  background: red; }
+

--- a/test/fixtures/sass-path/index.scss
+++ b/test/fixtures/sass-path/index.scss
@@ -1,0 +1,6 @@
+@import 'colors';
+
+body {
+  background: $color;
+}
+

--- a/test/fixtures/sass-path/orange/colors.scss
+++ b/test/fixtures/sass-path/orange/colors.scss
@@ -1,0 +1,1 @@
+$color: orange;

--- a/test/fixtures/sass-path/red/colors.scss
+++ b/test/fixtures/sass-path/red/colors.scss
@@ -1,0 +1,1 @@
+$color: red;


### PR DESCRIPTION
This is intended to [implement the `SASS_PATH` environment variable](https://github.com/sass/libsass/issues/90#issuecomment-57822790).

Fixes #1678.

## Tests

I've added two new API tests under `.render`:

- "should check SASS_PATH in the specified order"
- "should prefer include path over SASS_PATH"

If you run `mocha test/api.js` you should see these tests pass.

## Manual checking

You can test it manually using the test fixtures as follows:

### SASS_PATH is picked up

``` bash
$ fixdir=`pwd`/test/fixtures/sass-path
$ export SASS_PATH=$fixdir/red
$ bin/node-sass $fixdir/index.scss
body {
  background: red; }
```

### Earlier paths are preferred

``` bash
$ export SASS_PATH=$fixdir/orange:$fixdir/red
$ bin/node-sass $fixdir/index.scss
body {
  background: orange; }
```

### Specified include-paths still take precedence

``` bash
$ bin/node-sass $fixdir/index.scss --include-path $fixdir/red
body {
  background: red; }
```
