### PR TITLE
Publish tests to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lib",
     "scripts",
     "src",
+    "test",
     "vendor"
   ],
   "keywords": [


### PR DESCRIPTION
This is required for nodejs/citgm#165.

I conceed it will increase the size of the tarball. This isn't ideal
given the background noise of installation issues atm, but IMHO the
value of being in the CITGM is worth it.

The additional transparency into the binary download added by #1649
will go a long to alleviating the addition tarball size.