### PR TITLE
Add a timeout to the binary fetch request

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -21,8 +21,21 @@ var fs = require('fs'),
 
 function download(url, dest, cb) {
   var reportError = function(err) {
+    var timeoutMessge;
+
+    if (err.code === 'ETIMEDOUT') {
+      if (err.connect === true) {
+        // timeout is hit while your client is attempting to establish a connection to a remote machine
+        timeoutMessge = 'Timed out attemping to establish a remote connection';
+      } else {
+        timeoutMessge = 'Timed out whilst downloading the prebuilt binary';
+        // occurs any time the server is too slow to send back a part of the response
+      }
+
+    }
     cb(['Cannot download "', url, '": ', eol, eol,
       typeof err.message === 'string' ? err.message : err, eol, eol,
+      timeoutMessge ? timeoutMessge + eol + eol : timeoutMessge,
       'Hint: If github.com is not accessible in your location', eol,
       '      try setting a proxy via HTTP_PROXY, e.g. ', eol, eol,
       '      export HTTP_PROXY=http://example.com:1234',eol, eol,
@@ -34,9 +47,10 @@ function download(url, dest, cb) {
     return response.statusCode >= 200 && response.statusCode < 300;
   };
 
-  var options = { 
+  var options = {
     rejectUnauthorized: false,
     proxy: getProxy(),
+    timeout: 1000,
     headers: {
       'User-Agent': getUserAgent(),
     }


### PR DESCRIPTION
This PR adds a 1s timeout to the binary fetch request as well as a
useful error message.

It came to light in #1690 that the download can block for a long time.

```
npm info lifecycle node-sass@3.8.0~install: node-sass@3.8.0

> node-sass@3.8.0 install /Usersproject-path/node_modules/node-sass
> node scripts/install.js

Build timed out (after 35 minutes). Marking the build as failed.
```

We see a fair amount of hung installer issues that could be related
to this. The error output will give us another data point in those
cases.