### PR TITLE
Retry CLI specs that fail three times

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -11,6 +11,9 @@ var assert = require('assert'),
   LIBSASS_VERSION = null;
 
 describe('cli', function() {
+  // For some reason we experience random timeout failures in CI
+  // due to spawn hanging/failing silently. See #1692.
+  this.retries(4);
 
   before(function(done) {
     var bin = spawn(cli, ['-v']);


### PR DESCRIPTION
For some reason our test fail due to timeouts on seemingly random
cli tests. This instability has been growing worse. I've spent the
better part of the last two days looking into the issue without a
resolution. I'm starting to think it's an artefact cause by the
virtualisation used in CI, potentially related to resources
starvation.

The specs that failure do so trying to spawn a child process. The
process never spawns resulting in an eventual timeout. This is why
@nschonni attempt addressing this by increasing the timeout in #1668
failed.

Since the spawn failure is random, and catastrophic the best solution
in the short-medium term is to instruct mocha to retry failing tests
individually a couple times.

I've scoped this behaviour to the cli specs because at the moment
we have some specs that are not reentrant.

Fixes #1311