### PR TITLE
Add a nice little progress bar while downloading binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "mkdirp": "^0.5.1",
     "nan": "^2.3.2",
     "node-gyp": "^3.3.1",
+    "progress": "^1.1.8",
     "request": "^2.61.0",
     "sass-graph": "^2.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "mkdirp": "^0.5.1",
     "nan": "^2.3.2",
     "node-gyp": "^3.3.1",
-    "progress": "^1.1.8",
+    "npmlog": "^4.0.0",
     "request": "^2.61.0",
     "sass-graph": "^2.1.1"
   },


### PR DESCRIPTION
Forked from #1649.

This PR adds a small ascii progress bar to the binary download.
Stalled installations make up a steady background noise of our
issues. It's my hope that by making the binary fetch more
transparent we can stem the tide of those issues.

In order to address @saper's [concerns][1] this progress bar will
respect npm's `progress` config flag.

![sep-01-2016 21-33-35](https://cloud.githubusercontent.com/assets/579928/18165976/c84216dc-708b-11e6-9326-472e7057b7ac.gif)

Closes #1649

[1]: https://github.com/sass/node-sass/pull/1649#issuecomment-242720257