### PR TITLE
Increase the binary fetch request timeout

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -50,7 +50,7 @@ function download(url, dest, cb) {
   var options = {
     rejectUnauthorized: false,
     proxy: getProxy(),
-    timeout: 1000,
+    timeout: 60000,
     headers: {
       'User-Agent': getUserAgent(),
     }


### PR DESCRIPTION
The timeout applies to both the initial connection as well as
individual packets.

I found the 1s timeout to be really fragile when testing locally.
The intent of the timeout is to prevent the install process hanging
indefinitely. It makes sense to be very generous so this increases
the timeout to 60s.

