### PR TITLE
Remove the cli before test

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -7,24 +7,12 @@ var assert = require('assert'),
   stream = require('stream'),
   spawn = require('cross-spawn'),
   cli = path.join(__dirname, '..', 'bin', 'node-sass'),
-  fixture = path.join.bind(null, __dirname, 'fixtures'),
-  LIBSASS_VERSION = null;
+  fixture = path.join.bind(null, __dirname, 'fixtures');
 
 describe('cli', function() {
   // For some reason we experience random timeout failures in CI
   // due to spawn hanging/failing silently. See #1692.
   this.retries(4);
-
-  before(function(done) {
-    var bin = spawn(cli, ['-v']);
-    bin.stdout.setEncoding('utf8');
-    bin.stdout.once('data', function(data) {
-      LIBSASS_VERSION = data.trim().split(['\n'])
-          .filter(function(a) { return a.substr(0,7) === 'libsass'; })[0]
-          .split('\t')[1];
-      done();
-    });
-  });
 
   describe('node-sass < in.scss', function() {
     it('should read data from stdin', function(done) {
@@ -415,10 +403,6 @@ describe('cli', function() {
     });
 
     it('should compile with the --source-map option', function(done) {
-      if (LIBSASS_VERSION < '3.3') {
-        this.skip('Source map functionality broken in libsass < 3.3');
-      }
-
       var src = fixture('source-map/index.scss');
       var destCss = fixture('source-map/index.css');
       var destMap = fixture('source-map/index.map');


### PR DESCRIPTION
This test is super flakey for some reason, and `before` hooks also
appear to be get retried by mocha.

The was only required for when testing against LibSass < 3.3 which
is no longer the case. As such this hook serves no purpose.