### PR TITLE
ESLint 3.x updates

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
     "node": true
   },
   "globals": {},
+  "extends": "eslint:recommended",
   "rules": {
     "no-bitwise": 2,
     "camelcase": 0,
@@ -35,6 +36,11 @@
     ],
     "strict": 0,
     "no-undef": 2,
-    "no-unused-vars": 2
+    "no-unused-vars": 2,
+    "semi": 2,
+    "no-extra-semi": 2,
+    "no-redeclare": 2,
+    "block-scoped-var": 2,
+    "no-console": 0
   }
 }

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,2 +1,0 @@
-node_modules/**
-test/coverage/html

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,11 +46,13 @@ before_install:
 
 script:
   - npm install
+  - if [ $TRAVIS_OS_NAME == "linux" ] && [ $TRAVIS_NODE_VERSION == "4" ]; then
+      npm run lint || exit 1;
+    fi
   - npm test
 
 after_success:
   - if [ $TRAVIS_OS_NAME == "linux" ] && [ $TRAVIS_NODE_VERSION == "4" ]; then
-      npm run lint;
       npm run-script coverage;
     fi
 

--- a/bin/node-sass
+++ b/bin/node-sass
@@ -182,6 +182,7 @@ function getEmitter() {
  */
 
 function getOptions(args, options) {
+  var cssDir, sassDir, file, mapDir;
   options.src = args[0];
 
   if (args[1]) {
@@ -193,9 +194,9 @@ function getOptions(args, options) {
   }
 
   if (options.directory) {
-    var sassDir = path.resolve(options.directory);
-    var file = path.relative(sassDir, args[0]);
-    var cssDir = path.resolve(options.output);
+    sassDir = path.resolve(options.directory);
+    file = path.relative(sassDir, args[0]);
+    cssDir = path.resolve(options.output);
     options.dest = path.join(cssDir, file).replace(path.extname(file), '.css');
   }
 
@@ -215,9 +216,9 @@ function getOptions(args, options) {
       if (!options.directory) {
         options.sourceMap = path.resolve(options.sourceMapOriginal, path.basename(options.dest) + '.map');
       } else {
-        var sassDir = path.resolve(options.directory);
-        var file = path.relative(sassDir, args[0]);
-        var mapDir = path.resolve(options.sourceMapOriginal);
+        sassDir = path.resolve(options.directory);
+        file = path.relative(sassDir, args[0]);
+        mapDir = path.resolve(options.sourceMapOriginal);
         options.sourceMap = path.join(mapDir, file).replace(path.extname(file), '.css.map');
       }
     }
@@ -236,19 +237,20 @@ function getOptions(args, options) {
 
 function watch(options, emitter) {
   var buildGraph = function(options) {
+    var graph;
     var graphOptions = {
       loadPaths: options.includePath,
       extensions: ['scss', 'sass', 'css']
     };
 
     if (options.directory) {
-      var graph = grapher.parseDir(options.directory, graphOptions);
+      graph = grapher.parseDir(options.directory, graphOptions);
     } else {
-      var graph = grapher.parseFile(options.src, graphOptions);
+      graph = grapher.parseFile(options.src, graphOptions);
     }
 
     return graph;
-  }
+  };
 
   var watch = [];
   var graph = buildGraph(options);

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.8",
-    "eslint": "^2.9.0",
+    "eslint": "^3.4.0",
     "istanbul": "^0.4.2",
     "mocha": "^2.4.5",
     "mocha-lcov-reporter": "^1.2.0",

--- a/test/api.js
+++ b/test/api.js
@@ -147,7 +147,7 @@ describe('api', function() {
       var expectedRed = read(fixture('sass-path/expected-red.css'), 'utf8').trim();
       var expectedOrange = read(fixture('sass-path/expected-orange.css'), 'utf8').trim();
 
-      envIncludes = [
+      var envIncludes = [
         fixture('sass-path/red'),
         fixture('sass-path/orange')
       ];
@@ -175,7 +175,7 @@ describe('api', function() {
       var expectedRed = read(fixture('sass-path/expected-red.css'), 'utf8').trim();
       var expectedOrange = read(fixture('sass-path/expected-orange.css'), 'utf8').trim();
 
-      envIncludes = [
+      var envIncludes = [
         fixture('sass-path/red')
       ];
       process.env.SASS_PATH = envIncludes.join(path.delimiter);


### PR DESCRIPTION
- Bump to the 3.x branch since we only run it in Node 4
- Add the recommended options, but left our existing overrides
- Rename the eslintrc file to JSON to match the newer format that allows it to skip guessing
- Delete the old jshintignores since it is no longer applicable
- Enforce and fix a few variable declaration issues
- Ensure the lint runs during the regular Travis script section so it fails the build