### PR TITLE
Revert "Publish tests to npm"

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "lib",
     "scripts",
     "src",
-    "test",
     "vendor"
   ],
   "keywords": [


### PR DESCRIPTION
Reverts sass/node-sass#1688

This has caused multiple issues. We still need this but we need to rethink our approach.

Fixes #1701
Fixes #1699
Fixes dlmanning/gulp-sass#529