### PR TITLE
Sass spec without Ruby and git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "libsass"]
 	path = src/libsass
 	url = git://github.com/sass/libsass.git
-[submodule "test/sass-spec"]
-	path = test/fixtures/spec
-	url = https://github.com/sass/sass-spec.git

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "istanbul": "^0.4.2",
     "mocha": "^2.4.5",
     "mocha-lcov-reporter": "^1.2.0",
-    "rimraf": "^2.5.2"
+    "rimraf": "^2.5.2",
+    "sass-spec": "^3.3.6-3"
   }
 }

--- a/test/spec.js
+++ b/test/spec.js
@@ -6,28 +6,12 @@ var assert = require('assert'),
   sass = process.env.NODESASS_COV
       ? require('../lib-cov')
       : require('../lib'),
-  util = require('./util');
+  util = require('./util')
+  spec = require('sass-spec').dirname;
 
 describe('spec', function() {
   this.timeout(0);
   var suites = util.getSuites();
-
-  describe('test/sass-spec directory', function() {
-    it('should be a cloned into place', function(done) {
-      fs.exists(path.join(__dirname, 'fixtures', 'spec'), function(exists) {
-        if (!exists) {
-          throw new Error([
-            'test/fixtures/spec directory missing. Please clone it into place by',
-            'executing `git submodule update --init --recursive test/fixtures/spec`',
-            'from the project\'s root directory.'
-          ].join(' '));
-        }
-
-        assert(exists);
-        done();
-      });
-    });
-  });
 
   Object.keys(suites).forEach(function(suite) {
     var tests = Object.keys(suites[suite]);

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -1,6 +1,6 @@
 var fs = require('fs'),
   join = require('path').join,
-  spec = join(__dirname, '..', 'fixtures', 'spec', 'spec');
+  spec = join(require('sass-spec').dirname, 'spec');
 
 /**
  * Normalize CSS


### PR DESCRIPTION
Remove sass-spec git submodule by making the Sass Spec specs an npm package.
This compliments #1698 and together they accomplish #1686.

Fixes #1686

/cc @nschonni 
