### PR TITLE
User configurable cache folder for binary download

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -259,6 +259,17 @@ function getBinaryPath() {
 }
 
 /**
+ * Looks for the configured cache path. If none is found, fall back to the NPM
+ * cache folder
+ *
+ * @api public
+ */
+function getCachePath() {
+  return process.env.npm_config_sass_binary_cache ||
+         process.env.npm_config_cache;
+}
+
+/**
  * Does the supplied binary path exist
  *
  * @param {String} binaryPath
@@ -286,6 +297,7 @@ module.exports.hasBinary = hasBinary;
 module.exports.getBinaryUrl = getBinaryUrl;
 module.exports.getBinaryName = getBinaryName;
 module.exports.getBinaryPath = getBinaryPath;
+module.exports.getCachePath = getCachePath;
 module.exports.getVersionInfo = getVersionInfo;
 module.exports.getHumanEnvironment = getHumanEnvironment;
 module.exports.getInstalledBinaries = getInstalledBinaries;

--- a/test/runtime.js
+++ b/test/runtime.js
@@ -134,6 +134,29 @@ describe('runtime parameters', function() {
     });
 
   });
+
+  describe('Sass Binary Cache', function() {
+    var npmCacheDir;
+    before(function() {
+      npmCacheDir = process.env.npm_config_cache;
+    });
+
+    beforeEach(function() {
+      delete process.env.npm_config_sass_binary_cache;
+    });
+
+    it('npm config variable', function() {
+      var overridenCachePath = '/foo/bar/';
+      process.env.npm_config_sass_binary_cache = overridenCachePath;
+      var sass = require(extensionsPath);
+      assert.equal(sass.getCachePath(), overridenCachePath);
+    });
+
+    it('With no value, falls back to NPM cache', function() {
+      var sass = require(extensionsPath);
+      assert.equal(sass.getCachePath(), npmCacheDir);
+    });
+  });
 });
 
 // describe('library detection', function() {


### PR DESCRIPTION
New order of operations
1. Look for existing binary in vendor folder
2. Create target vendor folder
3. Look to see if we’ve cached a copy in the configured or NPM cache
4. Download to current version’s /CACHE/node-sass/version/binding_file
5. Copy the cached download to the regular vendor directory

Closes #1566