### PR TITLE
Note that libsass should be installed in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Follow @nodesass on twitter for release updates: https://twitter.com/nodesass
 
 ## Install
 
+Before beginning, ensure that [libsass](http://libsass.org/) is installed on your system.
+
 ```
 npm install node-sass
 ```


### PR DESCRIPTION
Was having trouble installing an npm package on a fresh install of Ubuntu. While obvious that libsass needs to be installed, including it in the instructions should help.