### PR TITLE
render: emit err.formatted

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -104,18 +104,12 @@ module.exports = function(options, emitter) {
     emitter.emit('render', result.css.toString());
   };
 
-  var error = function(error) {
-    emitter.emit('error', chalk.red(JSON.stringify(error, null, 2)));
-  };
-
-  var renderCallback = function(err, result) {
+  sass.render(renderOptions, function (err, result) {
     if (err) {
-      error(err);
+      emitter.emit('error', chalk.red(err.formatted));
     }
     else {
       success(result);
     }
-  };
-
-  sass.render(renderOptions, renderCallback);
+  });
 };

--- a/test/cli.js
+++ b/test/cli.js
@@ -762,7 +762,7 @@ describe('cli', function() {
       ]);
 
       bin.stderr.once('data', function(code) {
-        assert.equal(JSON.parse(code).message, 'doesn\'t exist!');
+        assert(code.toString('utf8').indexOf('doesn\'t exist!') !== -1);
         done();
       });
     });


### PR DESCRIPTION
fixes #1508 

The when encountering an error CLI will now print:

```
Error: Undefined variable: \"$variable\".
        on line X of X
>> color: $variable;
          ^
```

instead of:

```
{
  "formatted": "Error: Undefined variable: \"$variable\".\n        on line X of X\n>> \n   ----^\n",
  "message": "Undefined variable: \"$variable\".",
  "column": 1,
  "line": 1,
  "file": "FILE_NAME",
  "status": 1
} 
```
