### PR TITLE
POC for adding unit test coverage to install

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -9,7 +9,7 @@ var fs = require('fs'),
   sass = require('../lib/extensions'),
   request = require('request'),
   log = require('npmlog'),
-  pkg = require('../package.json');
+  userAgent = require('./util/useragent');
 
 /**
  * Download file, if succeeds save, if not delete
@@ -53,7 +53,7 @@ function download(url, dest, cb) {
     proxy: getProxy(),
     timeout: 60000,
     headers: {
-      'User-Agent': getUserAgent(),
+      'User-Agent': userAgent(),
     }
   };
 
@@ -92,18 +92,6 @@ function download(url, dest, cb) {
   } catch (err) {
     cb(err);
   }
-}
-
-/**
- * A custom user agent use for binary downloads.
- *
- * @api private
- */
-function getUserAgent() {
-  return [
-    'node/', process.version, ' ',
-    'node-sass-installer/', pkg.version
-  ].join('');
 }
 
 /**

--- a/scripts/util/useragent.js
+++ b/scripts/util/useragent.js
@@ -1,0 +1,13 @@
+var pkg = require('../../package.json');
+
+/**
+ * A custom user agent use for binary downloads.
+ *
+ * @api private
+ */
+module.exports = function() {
+  return [
+    'node/', process.version, ' ',
+    'node-sass-installer/', pkg.version
+  ].join('');
+};

--- a/test/useragent.js
+++ b/test/useragent.js
@@ -1,0 +1,15 @@
+var assert = require('assert'),
+  pkg = require('../package.json'),
+  ua = require('../scripts/util/useragent');
+
+describe('util', function() {
+  describe('useragent', function() {
+    it('should look as we expect', function() {
+      var reNode = 'node/' + process.version;
+      var reSass = 'node-sass-installer/' + pkg.version;
+      var reUA = new RegExp('^' + reNode + ' ' + reSass + '$');
+
+      assert.ok(reUA.test(ua()));
+    });
+  });
+});


### PR DESCRIPTION
The installer is getting more complicated. The core of it is a http
request which makes testing it difficult/messy. Pulling out core
logic into small util functions that we can unit test would give me
much more confidence moving forward.

I would prefer we don't export functions from scripts so people don't
start relying on undocumented APIs. This is why I opted for helper
utils but I'm not committed to them.

@nschonni this is along the lines of what I was thinking in our Slack
chat today. I've applied it the same approach in #1725 as an example.
Would love to hear your thoughts.