### PR TITLE
Remove skip download for CI flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: node_js
 
 compiler: gcc
 
-env:
-  global:
-    - SKIP_SASS_BINARY_DOWNLOAD_FOR_CI=true
-
 jobs:
   include:
     - stage: test
@@ -114,6 +110,7 @@ install:
   - npm install
 
 script:
+  - npm run build --force
   - npm test
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,6 @@
     - '%AppData%\npm-cache'
 
   environment:
-    SKIP_SASS_BINARY_DOWNLOAD_FOR_CI: true
     matrix:
       - nodejs_version: 0.10
         GYP_MSVS_VERSION: 2013
@@ -86,6 +85,7 @@
     - node --version
     - npm --version
     - npm install
+    - npm run build --force
 
   test: off
 
@@ -144,7 +144,6 @@
     - '%AppData%\npm-cache'
 
   environment:
-    SKIP_SASS_BINARY_DOWNLOAD_FOR_CI: true
     matrix:
       - nodejs_version: 0.10
         GYP_MSVS_VERSION: 2013
@@ -186,6 +185,7 @@
     - node --version
     - npm --version
     - npm install
+    - npm run build --force
 
   test_script:
     - ps: set-location -path c:\projects\node_modules\node-sass

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -96,11 +96,6 @@ function download(url, dest, cb) {
  */
 
 function checkAndDownloadBinary() {
-  if (process.env.SKIP_SASS_BINARY_DOWNLOAD_FOR_CI) {
-    console.log('Skipping downloading binaries on CI builds');
-    return;
-  }
-
   var cachedBinary = sass.getCachedBinary(),
     cachePath = sass.getBinaryCachePath(),
     binaryPath = sass.getBinaryPath();


### PR DESCRIPTION
This flag means we skip a bunch of code paths in CI which is not
ideal. Since we tell people to use `npm rebuild` we should eat our
own dog food.

With this patch we do an install, then do a rebuild hitting all the
major install code paths.

Fixes #1453

/cc @nschonni @saper
