### PR TITLE
Add watch mode to tests

### DIFF
--- a/test/api.js
+++ b/test/api.js
@@ -1839,4 +1839,139 @@ describe('api', function() {
       done();
     });
   });
+
+  describe('binding', function() {
+    beforeEach(function() {
+      delete require.cache[sassPath];
+    });
+
+    afterEach(function() {
+      delete require.cache[sassPath];
+    });
+
+    describe('missing error', function() {
+      it('should be useful', function() {
+        process.env.SASS_BINARY_NAME = 'Linux-x64-48';
+        assert.throws(
+          function() { require(sassPath); },
+          new RegExp('Missing binding.*?\\' + path.sep + 'vendor\\' + path.sep)
+        );
+      });
+
+      it('should list currently installed bindings', function() {
+        assert.throws(
+          function() { require(sassPath); },
+          function(err) {
+            var etx = require('../lib/extensions');
+
+            delete process.env.SASS_BINARY_NAME;
+
+            if ((err instanceof Error)) {
+              return err.message.indexOf(
+                etx.getHumanEnvironment(etx.getBinaryName())
+              ) !== -1;
+            }
+          }
+        );
+      });
+    });
+
+    describe('on unsupported environment', function() {
+      describe('with an unsupported architecture', function() {
+        var prevValue;
+
+        beforeEach(function() {
+          prevValue = process.arch;
+
+          Object.defineProperty(process, 'arch', {
+            get: function () { return 'foo'; }
+          });
+        });
+
+        afterEach(function() {
+          Object.defineProperty(process, 'arch', {
+            get: function () { return prevValue; }
+          });
+        });
+
+        it('should error', function() {
+          assert.throws(
+            function() { require(sassPath); },
+            'Node Sass does not yet support your current environment'
+          );
+        });
+
+        it('should inform the user the architecture is unsupported', function() {
+          assert.throws(
+            function() { require(sassPath); },
+            'Unsupported architecture (foo)'
+          );
+        });
+      });
+
+      describe('with an unsupported platform', function() {
+        var prevValue;
+
+        beforeEach(function() {
+          prevValue = process.platform;
+
+          Object.defineProperty(process, 'platform', {
+            value: 'bar'
+          });
+        });
+
+        afterEach(function() {
+          Object.defineProperty(process, 'platform', {
+            value: prevValue
+          });
+        });
+
+        it('should error', function() {
+          assert.throws(
+            function() { require(sassPath); },
+            'Node Sass does not yet support your current environment'
+          );
+        });
+
+        it('should inform the user the platform is unsupported', function() {
+          assert.throws(
+            function() { require(sassPath); },
+            'Unsupported platform (bar)'
+          );
+        });
+      });
+
+      describe('with an unsupported platform', function() {
+        var prevValue;
+
+        beforeEach(function() {
+          prevValue = process.versions.modules;
+
+          Object.defineProperty(process.versions, 'modules', {
+            value: 'baz'
+          });
+        });
+
+        afterEach(function() {
+          Object.defineProperty(process.versions, 'modules', {
+            value: prevValue
+          });
+        });
+
+        it('should error', function() {
+          assert.throws(
+            function() { require(sassPath); },
+            'Node Sass does not yet support your current environment'
+          );
+        });
+
+        it('should inform the user the runtime is unsupported', function() {
+          assert.throws(
+            function() { require(sassPath); },
+            'Unsupported runtime (baz)'
+          );
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
This also fixes process variables like `process.platform` not being properly restored after a test run because getters have a higher precedence.

Tested on both `v0.12.0` and `v6.7.0`.
