### PR TITLE
Add support for the --config CLI option

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -34,6 +34,7 @@ var cli = meow({
     '    --source-map true --source-map-contents sass',
     '',
     'Options',
+    '  -c, --config               Specify configuration options via JSON or .js file',
     '  -w, --watch                Watch a directory or file',
     '  -r, --recursive            Recursively watch directories or files',
     '  -o, --output               Output directory',
@@ -72,6 +73,7 @@ var cli = meow({
     'watch'
   ],
   string: [
+    'config',
     'functions',
     'importer',
     'include-path',
@@ -83,7 +85,8 @@ var cli = meow({
     'source-map-root'
   ],
   alias: {
-    c: 'source-comments',
+    c: 'config',
+    s: 'source-comments',
     i: 'indented-syntax',
     q: 'quiet',
     o: 'output',
@@ -93,6 +96,7 @@ var cli = meow({
     w: 'watch'
   },
   default: {
+    config: false,
     'include-path': process.cwd(),
     'indent-type': 'space',
     'indent-width': 2,
@@ -141,7 +145,7 @@ function globPattern(options) {
  * @api private
  */
 
-function getEmitter() {
+function getEmitter(options) {
   var emitter = new Emitter();
 
   emitter.on('error', function(err) {
@@ -182,7 +186,19 @@ function getEmitter() {
  */
 
 function getOptions(args, options) {
-  var cssDir, sassDir, file, mapDir;
+  var config, cssDir, sassDir, file, mapDir;
+  if (options.config) {
+    config = path.resolve(options.config);
+    try {
+      config = require(config);
+    } catch (error) {
+      getEmitter(options).emit('error', util.format(
+        'Unable to load config from "%s": %s',
+        options.config, error
+      ));
+    }
+    options = Object.assign(options, config);
+  }
   options.src = args[0];
 
   if (args[1]) {
@@ -384,7 +400,7 @@ function renderDir(options, emitter) {
  */
 
 var options = getOptions(cli.input, cli.flags);
-var emitter = getEmitter();
+var emitter = getEmitter(options);
 
 /**
  * Show usage if no arguments are supplied

--- a/bin/node-sass
+++ b/bin/node-sass
@@ -187,18 +187,6 @@ function getEmitter(options) {
 
 function getOptions(args, options) {
   var config, cssDir, sassDir, file, mapDir;
-  if (options.config) {
-    config = path.resolve(options.config);
-    try {
-      config = require(config);
-    } catch (error) {
-      getEmitter(options).emit('error', util.format(
-        'Unable to load config from "%s": %s',
-        options.config, error
-      ));
-    }
-    options = Object.assign(options, config);
-  }
   options.src = args[0];
 
   if (args[1]) {
@@ -241,6 +229,36 @@ function getOptions(args, options) {
   }
 
   return options;
+}
+
+
+/**
+ * Resolve
+ *
+ * @param {String} file
+ * @param {String} name
+ * @api private
+ */
+
+function resolve(file, name) {
+  var normalized = path.normalize(file)
+    .replace(/(.+)([\/|\\])$/, '$1');
+
+  var resolved;
+  try {
+    if (path.resolve(file) === normalized) {
+      resolved = require(file);
+    } else {
+      resolved = require(path.resolve(file));
+    }
+  } catch (error) {
+    emitter.emit('error', util.format(
+      'Unable to resolve %s "%s": %s',
+      name, file, error
+    ));
+  }
+
+  return resolved;
 }
 
 /**
@@ -327,20 +345,17 @@ function run(options, emitter) {
     emitter.emit('error', 'The --source-map option must be either a boolean or directory when compiling a directory');
   }
 
-  if (options.importer) {
-    if ((path.resolve(options.importer) === path.normalize(options.importer).replace(/(.+)([\/|\\])$/, '$1'))) {
-      options.importer = require(options.importer);
-    } else {
-      options.importer = require(path.resolve(options.importer));
-    }
+  if (options.importer && typeof options.importer === 'string') {
+    options.importer = resolve(options.importer, 'importer');
   }
 
-  if (options.functions) {
-    if ((path.resolve(options.functions) === path.normalize(options.functions).replace(/(.+)([\/|\\])$/, '$1'))) {
-      options.functions = require(options.functions);
-    } else {
-      options.functions = require(path.resolve(options.functions));
-    }
+  if (options.functions && typeof options.functions === 'string') {
+    options.functions = resolve(options.functions, 'functions');
+  }
+
+  if (options.config) {
+    var config = resolve(options.config, 'config');
+    options = Object.assign(options, config);
   }
 
   if (options.watch) {

--- a/bin/node-sass
+++ b/bin/node-sass
@@ -145,7 +145,7 @@ function globPattern(options) {
  * @api private
  */
 
-function getEmitter(options) {
+function getEmitter() {
   var emitter = new Emitter();
 
   emitter.on('error', function(err) {
@@ -415,7 +415,7 @@ function renderDir(options, emitter) {
  */
 
 var options = getOptions(cli.input, cli.flags);
-var emitter = getEmitter(options);
+var emitter = getEmitter();
 
 /**
  * Show usage if no arguments are supplied

--- a/bin/node-sass
+++ b/bin/node-sass
@@ -345,17 +345,17 @@ function run(options, emitter) {
     emitter.emit('error', 'The --source-map option must be either a boolean or directory when compiling a directory');
   }
 
+  if (options.config) {
+    var config = resolve(options.config, 'config');
+    options = Object.assign(options, config);
+  }
+
   if (options.importer && typeof options.importer === 'string') {
     options.importer = resolve(options.importer, 'importer');
   }
 
   if (options.functions && typeof options.functions === 'string') {
     options.functions = resolve(options.functions, 'functions');
-  }
-
-  if (options.config) {
-    var config = resolve(options.config, 'config');
-    options = Object.assign(options, config);
   }
 
   if (options.watch) {

--- a/bin/node-sass
+++ b/bin/node-sass
@@ -186,7 +186,7 @@ function getEmitter() {
  */
 
 function getOptions(args, options) {
-  var config, cssDir, sassDir, file, mapDir;
+  var cssDir, sassDir, file, mapDir;
   options.src = args[0];
 
   if (args[1]) {

--- a/bin/node-sass
+++ b/bin/node-sass
@@ -242,7 +242,7 @@ function getOptions(args, options) {
 
 function resolve(file, name) {
   var normalized = path.normalize(file)
-    .replace(/(.+)([\/|\\])$/, '$1');
+    .replace(/[\/|\\]$/, '');
 
   var resolved;
   try {

--- a/test/cli.js
+++ b/test/cli.js
@@ -664,31 +664,11 @@ describe('cli', function() {
       });
     });
 
-    it('should respect --config options in a .js file', function(done) {
+    it('should respect basic --config options in a .json file', function(done) {
 
-      var src = fixture('include-path/index.scss');
-      var args = [src, '--config', fixture('config/include-path.js')];
-      var expected = read(fixture('include-path/expected.css'), 'utf8')
-        .trim()
-        .replace(/\r\n/g, '\n');
-      var result = '';
-      var bin = spawn(cli, args);
-
-      bin.stdout.setEncoding('utf8');
-      bin.stdout.on('data', function(data) {
-        result += data;
-      });
-      bin.on('exit', function(status) {
-        assert.equal(status, 0, 'non-zero status: ' + status);
-        assert.equal(result.trim(), expected);
-        done();
-      });
-    });
-
-    it('resolves an importer defined in .json', function(done) {
-      var src = fixture('include-files/index.scss');
-      var args = [src, '--config', fixture('config/importer.json')];
-      var expected = read(fixture('include-files/expected-importer.css'), 'utf8')
+      var src = fixture('indent/index.sass');
+      var args = [src, '--config', fixture('config/indent.json')];
+      var expected = read(fixture('indent/expected.css'), 'utf8')
         .trim()
         .replace(/\r\n/g, '\n');
       var result = '';

--- a/test/cli.js
+++ b/test/cli.js
@@ -685,6 +685,48 @@ describe('cli', function() {
         });
     });
 
+    it('resolves an importer defined in .json', function() {
+
+      var src = fixture('include-path/index.scss');
+      var args = [src, '--config', fixture('config/importer.json')];
+      var expected = read(fixture('include-files/expected-importer.css'), 'utf8')
+        .trim()
+        .replace(/\r\n/g, '\n');
+      var result = '';
+      var bin = spawn(cli, args);
+
+      bin.stdout
+        .setEncoding('utf8')
+        .on('data', function(data) {
+          result += data.trim();
+        })
+        .once('end', function() {
+          assert.equal(result, expected);
+          done();
+        });
+    });
+
+    it('does not attempt to resolve an importer function defined in .js', function() {
+
+      var src = fixture('include-path/index.scss');
+      var args = [src, '--config', fixture('config/importer.js')];
+      var expected = read(fixture('include-files/expected-importer.css'), 'utf8')
+        .trim()
+        .replace(/\r\n/g, '\n');
+      var result = '';
+      var bin = spawn(cli, args);
+
+      bin.stdout
+        .setEncoding('utf8')
+        .on('data', function(data) {
+          result += data.trim();
+        })
+        .once('end', function() {
+          assert.equal(result, expected);
+          done();
+        });
+    });
+
     it('exits with an error when --config does not resolve', function(done) {
       var args = [
         fixture('include-path/index.scss'),

--- a/test/cli.js
+++ b/test/cli.js
@@ -657,7 +657,8 @@ describe('cli', function() {
       bin.stdout.on('data', function(data) {
         result += data;
       });
-      bin.stdout.once('end', function() {
+      bin.on('exit', function(status) {
+        assert.equal(status, 0, 'non-zero status: ' + status);
         assert.equal(result.trim(), expected);
         done();
       });
@@ -677,15 +678,15 @@ describe('cli', function() {
       bin.stdout.on('data', function(data) {
         result += data;
       });
-      bin.stdout.once('end', function() {
+      bin.on('exit', function(status) {
+        assert.equal(status, 0, 'non-zero status: ' + status);
         assert.equal(result.trim(), expected);
         done();
       });
     });
 
-    it('resolves an importer defined in .json', function() {
-
-      var src = fixture('include-path/index.scss');
+    it('resolves an importer defined in .json', function(done) {
+      var src = fixture('include-files/index.scss');
       var args = [src, '--config', fixture('config/importer.json')];
       var expected = read(fixture('include-files/expected-importer.css'), 'utf8')
         .trim()
@@ -697,15 +698,15 @@ describe('cli', function() {
       bin.stdout.on('data', function(data) {
         result += data;
       });
-      bin.stdout.once('end', function() {
+      bin.on('exit', function(status) {
+        assert.equal(status, 0, 'non-zero status: ' + status);
         assert.equal(result.trim(), expected);
         done();
       });
     });
 
-    it('does not attempt to resolve an importer function defined in .js', function() {
-
-      var src = fixture('include-path/index.scss');
+    it('does not attempt to resolve an importer function defined in .js', function(done) {
+      var src = fixture('include-files/index.scss');
       var args = [src, '--config', fixture('config/importer.js')];
       var expected = read(fixture('include-files/expected-importer.css'), 'utf8')
         .trim()
@@ -713,11 +714,12 @@ describe('cli', function() {
       var result = '';
       var bin = spawn(cli, args);
 
-      bin.stdout.setEncoding('utf8')
+      bin.stdout.setEncoding('utf8');
       bin.stdout.on('data', function(data) {
         result += data;
       });
-      bin.stdout.once('end', function() {
+      bin.on('exit', function(status) {
+        assert.equal(status, 0, 'non-zero status: ' + status);
         assert.equal(result.trim(), expected);
         done();
       });

--- a/test/cli.js
+++ b/test/cli.js
@@ -693,7 +693,7 @@ describe('cli', function() {
       var bin = spawn(cli, args);
       bin.stderr.once('data', function(data) {
         var error = data.toString();
-        assert.ok(/^Unable to load config/.test(error), error);
+        assert.ok(/^Unable to resolve config/.test(error), error);
       });
       bin.on('exit', function(status) {
         assert.equal(status, 1, 'non-1 status: ' + status);

--- a/test/cli.js
+++ b/test/cli.js
@@ -643,10 +643,10 @@ describe('cli', function() {
 
   describe('node-sass --config', function() {
 
-    it('should respect --config options in a .json file', function(done) {
+    it('should respect --config options in a .js file', function(done) {
 
       var src = fixture('include-path/index.scss');
-      var args = [src, '--config', fixture('config/include-path.json')];
+      var args = [src, '--config', fixture('config/include-path.js')];
       var expected = read(fixture('include-path/expected.css'), 'utf8')
         .trim()
         .replace(/\r\n/g, '\n');

--- a/test/cli.js
+++ b/test/cli.js
@@ -641,6 +641,68 @@ describe('cli', function() {
     });
   });
 
+  describe('config', function() {
+
+    it('should respect options defined in JSON', function(done) {
+
+      var src = fixture('include-path/index.scss');
+      var args = [src, '--config', fixture('config/include-path.json')];
+      var expected = read(fixture('include-path/expected.css'), 'utf8')
+        .trim()
+        .replace(/\r\n/g, '\n');
+      var result;
+      var bin = spawn(cli, args);
+
+      bin.stdout
+        .setEncoding('utf8')
+        .once('data', function(data) {
+          result = data.trim();
+        })
+        .once('end', function() {
+          assert.equal(result, expected);
+          done();
+        });
+    });
+
+    it('should respect options defined in .js', function(done) {
+
+      var src = fixture('include-path/index.scss');
+      var args = [src, '--config', fixture('config/include-path.js')];
+      var expected = read(fixture('include-path/expected.css'), 'utf8')
+        .trim()
+        .replace(/\r\n/g, '\n');
+      var result;
+      var bin = spawn(cli, args);
+
+      bin.stdout
+        .setEncoding('utf8')
+        .once('data', function(data) {
+          result = data.trim();
+        })
+        .once('end', function() {
+          assert.equal(result, expected);
+          done();
+        });
+    });
+
+    it('exits with an error when --config does not resolve', function(done) {
+      var args = [
+        fixture('include-path/index.scss'),
+        '--config', 'non-existent-config.json'
+      ];
+      var bin = spawn(cli, args);
+      bin.stderr.once('data', function(data) {
+        var error = data.toString();
+        assert.ok(/^Unable to load config/.test(error), error);
+      });
+      bin.on('exit', function(status) {
+        assert.equal(status, 1, 'non-1 status: ' + status);
+        done();
+      });
+    });
+
+  });
+
   describe('importer', function() {
     var dest = fixture('include-files/index.css');
     var src = fixture('include-files/index.scss');

--- a/test/cli.js
+++ b/test/cli.js
@@ -641,7 +641,7 @@ describe('cli', function() {
     });
   });
 
-  describe('config', function() {
+  describe('node-sass --config', function() {
 
     it('should respect --config options in a .json file', function(done) {
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -643,20 +643,20 @@ describe('cli', function() {
 
   describe('config', function() {
 
-    it('should respect options defined in JSON', function(done) {
+    it('should respect --config options in a .json file', function(done) {
 
       var src = fixture('include-path/index.scss');
       var args = [src, '--config', fixture('config/include-path.json')];
       var expected = read(fixture('include-path/expected.css'), 'utf8')
         .trim()
         .replace(/\r\n/g, '\n');
-      var result;
+      var result = '';
       var bin = spawn(cli, args);
 
       bin.stdout
         .setEncoding('utf8')
-        .once('data', function(data) {
-          result = data.trim();
+        .on('data', function(data) {
+          result += data.trim();
         })
         .once('end', function() {
           assert.equal(result, expected);
@@ -664,20 +664,20 @@ describe('cli', function() {
         });
     });
 
-    it('should respect options defined in .js', function(done) {
+    it('should respect --config options in a .js file', function(done) {
 
       var src = fixture('include-path/index.scss');
       var args = [src, '--config', fixture('config/include-path.js')];
       var expected = read(fixture('include-path/expected.css'), 'utf8')
         .trim()
         .replace(/\r\n/g, '\n');
-      var result;
+      var result = '';
       var bin = spawn(cli, args);
 
       bin.stdout
         .setEncoding('utf8')
-        .once('data', function(data) {
-          result = data.trim();
+        .on('data', function(data) {
+          result += data.trim();
         })
         .once('end', function() {
           assert.equal(result, expected);

--- a/test/cli.js
+++ b/test/cli.js
@@ -653,15 +653,14 @@ describe('cli', function() {
       var result = '';
       var bin = spawn(cli, args);
 
-      bin.stdout
-        .setEncoding('utf8')
-        .on('data', function(data) {
-          result += data.trim();
-        })
-        .once('end', function() {
-          assert.equal(result, expected);
-          done();
-        });
+      bin.stdout.setEncoding('utf8');
+      bin.stdout.on('data', function(data) {
+        result += data;
+      });
+      bin.stdout.once('end', function() {
+        assert.equal(result.trim(), expected);
+        done();
+      });
     });
 
     it('should respect --config options in a .js file', function(done) {
@@ -674,15 +673,14 @@ describe('cli', function() {
       var result = '';
       var bin = spawn(cli, args);
 
-      bin.stdout
-        .setEncoding('utf8')
-        .on('data', function(data) {
-          result += data.trim();
-        })
-        .once('end', function() {
-          assert.equal(result, expected);
-          done();
-        });
+      bin.stdout.setEncoding('utf8');
+      bin.stdout.on('data', function(data) {
+        result += data;
+      });
+      bin.stdout.once('end', function() {
+        assert.equal(result.trim(), expected);
+        done();
+      });
     });
 
     it('resolves an importer defined in .json', function() {
@@ -695,15 +693,14 @@ describe('cli', function() {
       var result = '';
       var bin = spawn(cli, args);
 
-      bin.stdout
-        .setEncoding('utf8')
-        .on('data', function(data) {
-          result += data.trim();
-        })
-        .once('end', function() {
-          assert.equal(result, expected);
-          done();
-        });
+      bin.stdout.setEncoding('utf8');
+      bin.stdout.on('data', function(data) {
+        result += data;
+      });
+      bin.stdout.once('end', function() {
+        assert.equal(result.trim(), expected);
+        done();
+      });
     });
 
     it('does not attempt to resolve an importer function defined in .js', function() {
@@ -716,15 +713,14 @@ describe('cli', function() {
       var result = '';
       var bin = spawn(cli, args);
 
-      bin.stdout
-        .setEncoding('utf8')
-        .on('data', function(data) {
-          result += data.trim();
-        })
-        .once('end', function() {
-          assert.equal(result, expected);
-          done();
-        });
+      bin.stdout.setEncoding('utf8')
+      bin.stdout.on('data', function(data) {
+        result += data;
+      });
+      bin.stdout.once('end', function() {
+        assert.equal(result.trim(), expected);
+        done();
+      });
     });
 
     it('exits with an error when --config does not resolve', function(done) {

--- a/test/fixtures/config/importer.js
+++ b/test/fixtures/config/importer.js
@@ -1,0 +1,3 @@
+module.exports = {
+  importer: require('../extras/my_custom_importer_data')
+};

--- a/test/fixtures/config/importer.json
+++ b/test/fixtures/config/importer.json
@@ -1,0 +1,3 @@
+{
+  "importer": "test/fixtures/extras/my_custom_importer_data"
+}

--- a/test/fixtures/config/importer.json
+++ b/test/fixtures/config/importer.json
@@ -1,3 +1,0 @@
-{
-  "importer": "test/fixtures/extras/my_custom_importer_data"
-}

--- a/test/fixtures/config/include-path.js
+++ b/test/fixtures/config/include-path.js
@@ -1,0 +1,7 @@
+var path = require('path');
+module.exports = {
+  includePath: [
+    path.join(__dirname, '..', 'include-path', 'functions'),
+    path.join(__dirname, '..', 'include-path', 'lib')
+  ]
+}

--- a/test/fixtures/config/include-path.js
+++ b/test/fixtures/config/include-path.js
@@ -4,4 +4,4 @@ module.exports = {
     path.join(__dirname, '..', 'include-path', 'functions'),
     path.join(__dirname, '..', 'include-path', 'lib')
   ]
-}
+};

--- a/test/fixtures/config/include-path.json
+++ b/test/fixtures/config/include-path.json
@@ -1,0 +1,6 @@
+{
+  "includePath": [
+    "test/fixtures/include-path/functions",
+    "test/fixtures/include-path/lib"
+  ]
+}

--- a/test/fixtures/config/indent.json
+++ b/test/fixtures/config/indent.json
@@ -1,0 +1,3 @@
+{
+  "indentedSyntax": true
+}


### PR DESCRIPTION
This PR adds support for a `--config` CLI option, which allows you to configure `node-sass` via a standalone JSON or `.js` file:

``` sh
echo '{"outputStyle":"compact"}' > config.json
node-sass --config path/to/config.json foo.scss > foo.css
echo 'module.exports = {outputStyle: "compact"};' > config.js
node-sass --config config.js bar.scss > bar.css
```

This makes it much simpler configure multiple include paths for, say, both one-off builds and watch tasks, simplifying npm scripts:

``` json
{
  "scripts": {
    "build-css": "node-sass --config sass.config.js",
    "watch-css": "node-sass --config sass.config.js --watch"
  }
}
```

Some things to be aware of:
- There's currently no support for overriding options from the config via an explicit CLI argument because of the way that `meow()` is called. I think the way to do this would be to nix the `default` option from `meow()` and do something like:
  
  ``` js
  options = Object.assign({}, defaults, config, options);
  ```
- I reassigned the `-c` alias to `--config` from `--source-comments` (which was undocumented anyway), and added an `-s` alias for the latter.
- I originally had some tests for configuring `includePath` and `importer` via JSON, but these were difficult to get right, and brittle because the cwd from which they're resolved changes based on how you call `mocha`. It might be worth suggesting in the docs that users configure the "resolved" options (`includePath`, `importer`, and `functions`) via JS so that they can more easily specify absolute paths.
