### PR TITLE
Fix proxy config for binary download

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -9,9 +9,7 @@ var fs = require('fs'),
   sass = require('../lib/extensions'),
   request = require('request'),
   log = require('npmlog'),
-  pkg = require('../package.json'),
-  proxy = require('./util/proxy'),
-  userAgent = require('./util/useragent');
+  downloadOptions = require('./util/downloadoptions');
 
 /**
  * Download file, if succeeds save, if not delete
@@ -50,19 +48,10 @@ function download(url, dest, cb) {
     return response.statusCode >= 200 && response.statusCode < 300;
   };
 
-  var options = {
-    rejectUnauthorized: false,
-    proxy: proxy(),
-    timeout: 60000,
-    headers: {
-      'User-Agent': userAgent(),
-    }
-  };
-
   console.log('Start downloading binary at', url);
 
   try {
-    request(url, options, function(err, response) {
+    request(url, downloadOptions(), function(err, response) {
       if (err) {
         reportError(err);
       } else if (!successful(response)) {

--- a/scripts/util/downloadoptions.js
+++ b/scripts/util/downloadoptions.js
@@ -1,0 +1,30 @@
+var proxy = require('./proxy'),
+  userAgent = require('./useragent');
+
+/**
+ * The options passed to request when downloading the bibary
+ *
+ * There some nuance to how request handles options. Specifically
+ * we've been caught by their usage of `hasOwnProperty` rather than
+ * falsey checks. By moving the options generation into a util helper
+ * we can test for regressions.
+ *
+ * @return {Object} an options object for request
+ * @api private
+ */
+module.exports = function() {
+  var options = {
+    rejectUnauthorized: false,
+    timeout: 60000,
+    headers: {
+      'User-Agent': userAgent(),
+    }
+  };
+
+  var proxyConfig = proxy();
+  if (proxyConfig) {
+    options.proxy = proxyConfig;
+  }
+
+  return options;
+};

--- a/test/downloadoptions.js
+++ b/test/downloadoptions.js
@@ -1,0 +1,71 @@
+var assert = require('assert'),
+  ua = require('../scripts/util/useragent'),
+  opts = require('../scripts/util/downloadoptions');
+
+
+describe('util', function() {
+  describe('downloadoptions', function() {
+    describe('without a proxy', function() {
+      it('should look as we expect', function() {
+        var expected = {
+          rejectUnauthorized: false,
+          timeout: 60000,
+          headers: {
+            'User-Agent': ua(),
+          }
+        };
+
+        assert.deepEqual(opts(), expected);
+      });
+    });
+
+    describe('with an npm config proxy', function() {
+      var proxy = 'http://test.proxy:1234';
+
+      before(function() {
+        process.env.npm_config_proxy = proxy;
+      });
+
+      after(function() {
+        delete process.env.npm_config_proxy;
+      });
+
+      it('should look as we expect', function() {
+        var expected = {
+          rejectUnauthorized: false,
+          proxy: proxy,
+          timeout: 60000,
+          headers: {
+            'User-Agent': ua(),
+          }
+        };
+
+        assert.deepEqual(opts(), expected);
+      });
+    });
+
+    describe('with an env proxy proxy', function() {
+      var proxy = 'http://test.proxy:1234';
+
+      before(function() {
+        process.env.HTTP_PROXY = proxy;
+      });
+
+      after(function() {
+        delete process.env.HTTP_PROXY;
+      });
+
+      it('should look as we expect', function() {
+        var expected = {
+          rejectUnauthorized: false,
+          timeout: 60000,
+          headers: {
+            'User-Agent': ua(),
+          }
+        };
+
+        assert.deepEqual(opts(), expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
In #1725 we started setting `proxy: ''` to defer proxy resolution
logic to request. However `request` uses `hasOwnProperty` rather
than falsey checks to determine if an option has been set. This
caused `request` to believe were configuring a proxy so it didn't
do it's own proxy resolution.

Fixes #1785
Fixes #1787