### PR TITLE
Use npmlog for all install script output

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -181,9 +181,11 @@ function getBinaryName() {
   } else if (pkg.nodeSassConfig && pkg.nodeSassConfig.binaryName) {
     binaryName = pkg.nodeSassConfig.binaryName;
   } else {
-    binaryName = [process.platform, '-',
-                  process.arch, '-',
-                  process.versions.modules].join('');
+    binaryName = [
+      process.platform, '-',
+      process.arch, '-',
+      process.versions.modules
+    ].join('');
   }
 
   return [binaryName, 'binding.node'].join('_');

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -48,7 +48,7 @@ function download(url, dest, cb) {
     return response.statusCode >= 200 && response.statusCode < 300;
   };
 
-  log.http('node-sass install', 'Start downloading binary at ' + url);
+  log.http('node-sass install', 'Downloading binary from %s', url);
 
   try {
     request(url, downloadOptions(), function(err, response) {
@@ -57,12 +57,13 @@ function download(url, dest, cb) {
       } else if (!successful(response)) {
         reportError(['HTTP error', response.statusCode, response.statusMessage].join(' '));
       } else {
+        log.http('node-sass install', 'Download complete');
         cb();
       }
     })
     .on('response', function(response) {
       var length = parseInt(response.headers['content-length'], 10);
-      var progress = log.newItem(url, length);
+      var progress = log.newItem('', length);
 
       if (successful(response)) {
         response.pipe(fs.createWriteStream(dest));
@@ -108,7 +109,7 @@ function checkAndDownloadBinary() {
         return;
       }
 
-      log.info('node-sass install', 'Binary downloaded and installed at ' + sass.getBinaryPath());
+      log.info('node-sass install', 'Binary saved at %s', sass.getBinaryPath());
     });
   });
 }


### PR DESCRIPTION
In for a penny in for a pound. I also  noticed that #1786 resulted
in some funky looking console output. I've taken this opportunity to
tidy up our install script output whilst maintaining the information
useful for debugging install issues.

```
> node-sass@3.11.3 install /Users/xzyfer/Projects/Sass/upstream/node-sass
> node scripts/install.js

http node-sass install Downloading binary from https://github.com/sass/node-sass/releases/download/v3.11.3/darwin-x64-47_binding.node
http node-sass install Download complete
info node-sass install Binary saved at /Users/xzyfer/Projects/Sass/upstream/node-sass/vendor/darwin-x64-47/binding.node

> node-sass@3.11.3 postinstall /Users/xzyfer/Projects/Sass/upstream/node-sass
> node scripts/build.js

info node-sass build Binary found at /Users/xzyfer/Projects/Sass/upstream/node-sass/vendor/darwin-x64-47/binding.node
info node-sass build Testing binary
info node-sass build Binary is fine

> node-sass@3.11.3 prepublish /Users/xzyfer/Projects/Sass/upstream/node-sass
> not-in-install && node scripts/prepublish.js || in-install
```