### PR TITLE
Use console for logging instead of npmlog

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -7,7 +7,6 @@ var pkg = require('../package.json'),
   mkdir = require('mkdirp'),
   path = require('path'),
   spawn = require('cross-spawn'),
-  log = require('npmlog'),
   sass = require('../lib/extensions');
 
 /**
@@ -28,23 +27,23 @@ function afterBuild(options) {
 
   mkdir(path.dirname(install), function(err) {
     if (err && err.code !== 'EEXIST') {
-      log.error('node-sass build', err.message);
+      console.error(err.message);
       return;
     }
 
     fs.stat(target, function(err) {
       if (err) {
-        log.error('node-sass build', 'Build succeeded but target not found');
+        console.error('Build succeeded but target not found');
         return;
       }
 
       fs.rename(target, install, function(err) {
         if (err) {
-          log.error('node-sass build', err.message);
+          console.error(err.message);
           return;
         }
 
-        log.info('node-sass build', 'Installed to %s', install);
+        console.log('Installed to', install);
       });
     });
   });
@@ -76,8 +75,8 @@ function manageProcess(proc, cb) {
  */
 
 function initSubmodules(cb) {
-  log.info('node-sass build', 'Detected a git install');
-  log.info('node-sass build', 'Cloning LibSass into src/libsass');
+  console.log('Detected a git install');
+  console.log('Cloning LibSass into src/libsass');
 
   var clone = spawn('git', ['clone', 'https://github.com/sass/libsass.git', './src/libsass']);
   manageProcess(clone, function(err) {
@@ -86,7 +85,7 @@ function initSubmodules(cb) {
       return;
     }
 
-    log.info('node-sass build', 'Checking out LibSass to %s', pkg.libsass);
+    console.log('Checking out LibSass to', pkg.libsass);
 
     var checkout = spawn('git', ['checkout', pkg.libsass], { cwd: './src/libsass' });
     manageProcess(checkout, function(err) {
@@ -128,7 +127,7 @@ function installGitDependencies(options, cb) {
 function build(options) {
   installGitDependencies(options, function(err) {
     if (err) {
-      log.error('node-sass build', err.message);
+      console.error(err.message);
       process.exit(1);
     }
 
@@ -137,7 +136,7 @@ function build(options) {
         return ['--', subject, '=', process.env[subject.toUpperCase()] || ''].join('');
       })).concat(options.args);
 
-    log.info('node-sass build', [process.execPath].concat(args).join(' '));
+    console.log('Building:', [process.execPath].concat(args).join(' '));
 
     var proc = spawn(process.execPath, args, {
       stdio: [0, 1, 2]
@@ -150,9 +149,9 @@ function build(options) {
       }
 
       if (errorCode === 127 ) {
-        log.error('node-sass build', 'node-gyp not found!');
+        console.error('node-gyp not found!');
       } else {
-        log.error('node-sass build', 'Build failed with error code: %d', errorCode);
+        console.error('Build failed with error code:', errorCode);
       }
 
       process.exit(1);
@@ -207,18 +206,18 @@ function testBinary(options) {
     return build(options);
   }
 
-  log.info('node-sass build', 'Binary found at %s', sass.getBinaryPath());
-  log.info('node-sass build', 'Testing binary');
+  console.log('Binary found at', sass.getBinaryPath());
+  console.log('Testing binary');
 
   try {
     require('../').renderSync({
       data: 's { a: ss }'
     });
 
-    log.info('node-sass build', 'Binary is fine');
+    console.log('Binary is fine');
   } catch (e) {
-    log.error('node-sass build', 'Binary has a problem: %s', e);
-    log.info('node-sass build', 'Building the binary locally');
+    console.log('Binary has a problem:', e);
+    console.log('Building the binary locally');
 
     return build(options);
   }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -48,7 +48,7 @@ function download(url, dest, cb) {
     return response.statusCode >= 200 && response.statusCode < 300;
   };
 
-  log.http('node-sass install', 'Downloading binary from %s', url);
+  console.log('Downloading binary from', url);
 
   try {
     request(url, downloadOptions(), function(err, response) {
@@ -57,7 +57,7 @@ function download(url, dest, cb) {
       } else if (!successful(response)) {
         reportError(['HTTP error', response.statusCode, response.statusMessage].join(' '));
       } else {
-        log.http('node-sass install', 'Download complete');
+        console.log('Download complete');
         cb();
       }
     })
@@ -94,7 +94,7 @@ function download(url, dest, cb) {
 
 function checkAndDownloadBinary() {
   if (process.env.SKIP_SASS_BINARY_DOWNLOAD_FOR_CI) {
-    log.info('node-sass install', 'Skipping downloading binaries on CI builds');
+    console.log('Skipping downloading binaries on CI builds');
     return;
   }
 
@@ -103,45 +103,45 @@ function checkAndDownloadBinary() {
     binaryPath = sass.getBinaryPath();
 
   if (sass.hasBinary(binaryPath)) {
-    log.info('node-sass build', 'Binary found at %s', binaryPath);
+    console.log('node-sass build', 'Binary found at', binaryPath);
     return;
   }
 
   try {
     mkdir.sync(path.dirname(binaryPath));
   } catch (err) {
-    log.error('node-sass install', 'Unable to save binary to %s: %s', path.dirname(binaryPath), err);
+    console.error('Unable to save binary', path.dirname(binaryPath), ':', err);
     return;
   }
 
   if (cachedBinary) {
-    log.info('node-sass install', 'Cached binary found at %s', cachedBinary);
+    console.log('Cached binary found at', cachedBinary);
     fs.createReadStream(cachedBinary).pipe(fs.createWriteStream(binaryPath));
     return;
   }
 
   download(sass.getBinaryUrl(), binaryPath, function(err) {
     if (err) {
-      log.error('node-sass install', err);
+      console.error(err);
       return;
     }
 
-    log.info('node-sass install', 'Binary saved at %s', binaryPath);
+    console.log('Binary saved to', binaryPath);
 
     cachedBinary = path.join(cachePath, sass.getBinaryName());
 
     if (cachePath) {
-      log.info('node-sass install', 'Caching binary to %s', cachedBinary);
+      console.log('Caching binary to', cachedBinary);
 
       try {
         mkdir.sync(path.dirname(cachedBinary));
         fs.createReadStream(binaryPath)
           .pipe(fs.createWriteStream(cachedBinary))
           .on('error', function (err) {
-            log.error('node-sass install', 'Failed to cache binary: %s', err);
+            console.log('Failed to cache binary:', err);
           });
       } catch (err) {
-        log.error('node-sass install', 'Failed to cache binary: %s', err);
+        console.log('Failed to cache binary:', err);
       }
     }
   });


### PR DESCRIPTION
We started using npmlog for install logging in #1786, then went all
out in #1796. npmlog has caused some issues, namely #1805. It doesn't
provided enough value for how troublesome it is.

The problem sparked #1786 was resolved in 5c7fb7f675.