### PR TITLE
Pass NODEDIR to node-gyp

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -132,7 +132,7 @@ function build(options) {
     }
 
     var args = [require.resolve(path.join('node-gyp', 'bin', 'node-gyp.js')), 'rebuild', '--verbose'].concat(
-      ['libsass_ext', 'libsass_cflags', 'libsass_ldflags', 'libsass_library'].map(function(subject) {
+      ['libsass_ext', 'libsass_cflags', 'libsass_ldflags', 'libsass_library', 'nodedir'].map(function(subject) {
         return ['--', subject, '=', process.env[subject.toUpperCase()] || ''].join('');
       })).concat(options.args);
 


### PR DESCRIPTION
Sometimes (e.g. for offline builds) it's convenient to be able to pass a custom `--nodedir` to `node-gyp`.