### PR TITLE
Check options to be an object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -182,6 +182,9 @@ function buildIncludePaths(options) {
  */
 
 function getOptions(opts, cb) {
+  if (typeof opts !== 'object') {
+    throw new Error('Invalid: options is not an object.');
+  }
   var options = clonedeep(opts || {});
 
   options.sourceComments = options.sourceComments || false;


### PR DESCRIPTION
This helps fix the case when passing in a string instead of object for options (when used programmatically).

Fix #1824.