### PR TITLE
Removed top-level return statement from cli

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -428,5 +428,3 @@ if (options.src) {
     run(options, emitter);
   });
 }
-
-return emitter;


### PR DESCRIPTION
Looking at [the commit that introduced it,](https://github.com/sass/node-sass/commit/c7539f19d2e97cd52cf7a52c00c8e8fff3f4409a) it seems that it's leftover of the `cli.js` which was then required in a separate file.

Closes #1826 
