### PR TITLE
Drop dependency lodash.isarray

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "in-publish": "^2.0.0",
     "lodash.assign": "^4.2.0",
     "lodash.clonedeep": "^4.3.2",
-    "lodash.isarray": "^4.0.0",
     "lodash.mergewith": "^4.6.0",
     "meow": "^3.7.0",
     "mkdirp": "^0.5.1",

--- a/test/spec.js
+++ b/test/spec.js
@@ -9,7 +9,6 @@ var assert = require('assert'),
   readYaml = require('read-yaml'),
   mergeWith = require('lodash.mergewith'),
   assign = require('lodash.assign'),
-  isArray = require('lodash.isarray'),
   glob = require('glob'),
   specPath = require('sass-spec').dirname.replace(/\\/g, '/'),
   impl = 'libsass',
@@ -116,7 +115,7 @@ var specSuite = {
 };
 
 function customizer(objValue, srcValue) {
-  if (isArray(objValue)) {
+  if (Array.isArray(objValue)) {
     return objValue.concat(srcValue);
   }
 }


### PR DESCRIPTION
Fixes #1829.

The code of `lodash.isarray` is actually this:
```js
var isArray = Array.isArray;

module.exports = isArray;
```