### PR TITLE
Add a platform variant for installing a musl binary

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -182,8 +182,14 @@ function getBinaryName() {
   } else if (pkg.nodeSassConfig && pkg.nodeSassConfig.binaryName) {
     binaryName = pkg.nodeSassConfig.binaryName;
   } else {
+    var platform = process.platform;
+    var variant = getPlatformVariant();
+    if (variant !== "") {
+      platform += "_" + variant;
+    }
+
     binaryName = [
-      process.platform, '-',
+      platform, '-',
       process.arch, '-',
       process.versions.modules
     ].join('');
@@ -357,6 +363,23 @@ function getVersionInfo(binding) {
     ['node-sass', pkg.version, '(Wrapper)', '[JavaScript]'].join('\t'),
     ['libsass  ', binding.libsassVersion(), '(Sass Compiler)', '[C/C++]'].join('\t'),
   ].join(eol);
+}
+
+/**
+ * Gets the platform variant, either an empty string for non-Linux systems or the
+ * libc implementation (glibc|musl) on Linux.
+ *
+ * @api public
+ */
+
+function getPlatformVariant() {
+  if (process.platform != "linux") {
+    return "";
+  }
+  if (fs.readFileSync(process.execPath).indexOf('libc.musl-x86_64.so.1')) {
+    return "musl";
+  }
+  return "glibc";
 }
 
 module.exports.hasBinary = hasBinary;

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -381,7 +381,14 @@ function getPlatformVariant() {
   }
 
   try {
-    contents = fs.readFileSync(process.execPath).toString();
+    contents = fs.readFileSync(process.execPath);
+
+    // Buffer.indexOf was added in v1.5.0 so cast to string for old node
+    // Delay contents.toStrings because it's expensive
+    if (!contents.indexOf) {
+      contents = contents.toString();
+    }
+
     if (contents.indexOf('libc.musl-x86_64.so.1') !== -1) {
       return 'musl';
     }

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -172,7 +172,9 @@ function getArgument(name, args) {
  */
 
 function getBinaryName() {
-  var binaryName;
+  var binaryName,
+    variant,
+    platform = process.platform;
 
   if (getArgument('--sass-binary-name')) {
     binaryName = getArgument('--sass-binary-name');
@@ -183,9 +185,8 @@ function getBinaryName() {
   } else if (pkg.nodeSassConfig && pkg.nodeSassConfig.binaryName) {
     binaryName = pkg.nodeSassConfig.binaryName;
   } else {
-    var platform = process.platform;
-    var variant = getPlatformVariant();
-    if (variant !== '') {
+    variant = getPlatformVariant();
+    if (variant) {
       platform += '_' + variant;
     }
 
@@ -373,10 +374,12 @@ function getVersionInfo(binding) {
  */
 
 function getPlatformVariant() {
+  var contents = '';
+
   if (process.platform !== 'linux') {
     return '';
   }
-  var contents = '';
+
   try {
     contents = fs.readFileSync(process.execPath);
     if (!contents.indexOf) {
@@ -386,6 +389,7 @@ function getPlatformVariant() {
       return 'musl';
     }
   } catch (err) { } // eslint-disable-line no-empty
+
   return '';
 }
 

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -384,8 +384,8 @@ function getPlatformVariant() {
     if (contents.indexOf('libc.musl-x86_64.so.1') !== -1) {
       return 'musl';
     }
-  } catch (err) { }
-  return ''
+  } catch (err) { } // eslint-disable-line no-empty
+  return '';
 }
 
 module.exports.hasBinary = hasBinary;

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -184,7 +184,7 @@ function getBinaryName() {
   } else {
     var platform = process.platform;
     var variant = getPlatformVariant();
-    if (variant != '') {
+    if (variant !== '') {
       platform += '_' + variant;
     }
 
@@ -372,10 +372,10 @@ function getVersionInfo(binding) {
  */
 
 function getPlatformVariant() {
-  if (process.platform != 'linux') {
+  if (process.platform !== 'linux') {
     return '';
   }
-  if (fs.readFileSync(process.execPath).indexOf('libc.musl-x86_64.so.1') != -1) {
+  if (fs.readFileSync(process.execPath).indexOf('libc.musl-x86_64.so.1') !== -1) {
     return 'musl';
   }
   return '';

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -377,7 +377,10 @@ function getPlatformVariant() {
   }
   var contents = '';
   try {
-    contents = fs.readFileSync('foo.bar').toString();
+    contents = fs.readFileSync('foo.bar');
+    if (!contents.indexOf) {
+      contents = contents.toString();
+    }
     if (contents.indexOf('libc.musl-x86_64.so.1') !== -1) {
       return 'musl';
     }

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -184,13 +184,13 @@ function getBinaryName() {
   } else {
     var platform = process.platform;
     var variant = getPlatformVariant();
-    if (variant !== "") {
-      platform += "_" + variant;
+    if (variant != '') {
+      platform += '_' + variant;
     }
 
     // for backwards compat, glibc variant is the default
-    if (platform === "linux_glibc") {
-      platform = "linux";
+    if (platform === 'linux_glibc') {
+      platform = 'linux';
     }
 
     binaryName = [
@@ -378,13 +378,13 @@ function getVersionInfo(binding) {
  */
 
 function getPlatformVariant() {
-  if (process.platform != "linux") {
-    return "";
+  if (process.platform != 'linux') {
+    return '';
   }
-  if (fs.readFileSync(process.execPath).indexOf('libc.musl-x86_64.so.1') !== -1) {
-    return "musl";
+  if (fs.readFileSync(process.execPath).indexOf('libc.musl-x86_64.so.1') != -1) {
+    return 'musl';
   }
-  return "glibc";
+  return 'glibc';
 }
 
 module.exports.hasBinary = hasBinary;

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -375,10 +375,14 @@ function getPlatformVariant() {
   if (process.platform !== 'linux') {
     return '';
   }
-  if (fs.readFileSync(process.execPath).indexOf('libc.musl-x86_64.so.1') !== -1) {
-    return 'musl';
-  }
-  return '';
+  var contents = '';
+  try {
+    contents = fs.readFileSync('foo.bar').toString();
+    if (contents.indexOf('libc.musl-x86_64.so.1') !== -1) {
+      return 'musl';
+    }
+  } catch (err) { }
+  return ''
 }
 
 module.exports.hasBinary = hasBinary;

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -381,7 +381,7 @@ function getPlatformVariant() {
   if (process.platform != "linux") {
     return "";
   }
-  if (fs.readFileSync(process.execPath).indexOf('libc.musl-x86_64.so.1')) {
+  if (fs.readFileSync(process.execPath).indexOf('libc.musl-x86_64.so.1') !== -1) {
     return "musl";
   }
   return "glibc";

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -188,6 +188,11 @@ function getBinaryName() {
       platform += "_" + variant;
     }
 
+    // for backwards compat, glibc variant is the default
+    if (platform === "linux_glibc") {
+      platform = "linux";
+    }
+
     binaryName = [
       platform, '-',
       process.arch, '-',

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -188,11 +188,6 @@ function getBinaryName() {
       platform += '_' + variant;
     }
 
-    // for backwards compat, glibc variant is the default
-    if (platform === 'linux_glibc') {
-      platform = 'linux';
-    }
-
     binaryName = [
       platform, '-',
       process.arch, '-',
@@ -371,8 +366,7 @@ function getVersionInfo(binding) {
 }
 
 /**
- * Gets the platform variant, either an empty string for non-Linux systems or the
- * libc implementation (glibc|musl) on Linux.
+ * Gets the platform variant, currently either an empty string or 'musl' for Linux/musl platforms.
  *
  * @api public
  */
@@ -384,7 +378,7 @@ function getPlatformVariant() {
   if (fs.readFileSync(process.execPath).indexOf('libc.musl-x86_64.so.1') != -1) {
     return 'musl';
   }
-  return 'glibc';
+  return '';
 }
 
 module.exports.hasBinary = hasBinary;

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -381,10 +381,7 @@ function getPlatformVariant() {
   }
 
   try {
-    contents = fs.readFileSync(process.execPath);
-    if (!contents.indexOf) {
-      contents = contents.toString();
-    }
+    contents = fs.readFileSync(process.execPath).toString();
     if (contents.indexOf('libc.musl-x86_64.so.1') !== -1) {
       return 'musl';
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sass",
-  "version": "3.13.1",
+  "version": "4.0.0",
   "libsass": "3.4.0",
   "description": "Wrapper around libsass",
   "license": "MIT",


### PR DESCRIPTION
This adds a new element `platformvariant` to the naming scheme for precompiled binding binaries:

```
{platform}_{platformvariant}-{arch}-{abiversion}_binding
```

This allows for statically compiled musl binaries to be made available for Alpine Linux.

The check for whether this is needed is done by detecting symbols in the node binary, as suggested in https://github.com/sass/node-sass/issues/1589#issuecomment-266470069. I don't love this approach, but it's a whole lot simpler than `exec`'ing out to `ldd`. 

See https://github.com/sass/node-sass/issues/1589 for more details on background.

Tests:

```bash 
$ docker run -v "$PWD:/code" --rm -w /code node:7-alpine node scripts/install.js 
Downloading binary from https://github.com/sass/node-sass/releases/download/v4.0.0/linux_musl-x64-51_binding.node 
```

```bash 
$ docker run -v "$PWD:/code" --rm -w /code node:7 node scripts/install.js 
Downloading binary from https://github.com/sass/node-sass/releases/download/v4.0.0/linux-x64-51_binding.node
```
