### PR TITLE
Remove the git fallback

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -2,8 +2,7 @@
  * node-sass: scripts/build.js
  */
 
-var pkg = require('../package.json'),
-  fs = require('fs'),
+var fs = require('fs'),
   mkdir = require('mkdirp'),
   path = require('path'),
   spawn = require('cross-spawn'),
@@ -50,74 +49,6 @@ function afterBuild(options) {
 }
 
 /**
- * manageProcess
- *
- * @param {ChildProcess} proc
- * @param {Function} cb
- * @api private
- */
-
-function manageProcess(proc, cb) {
-  var errorMsg = '';
-  proc.stderr.on('data', function(data) {
-    errorMsg += data.toString();
-  });
-  proc.on('close', function(code) {
-    cb(code === 0 ? null : { message: errorMsg });
-  });
-}
-
-/**
- * initSubmodules
- *
- * @param {Function} cb
- * @api private
- */
-
-function initSubmodules(cb) {
-  console.log('Detected a git install');
-  console.log('Cloning LibSass into src/libsass');
-
-  var clone = spawn('git', ['clone', 'https://github.com/sass/libsass.git', './src/libsass']);
-  manageProcess(clone, function(err) {
-    if (err) {
-      cb(err);
-      return;
-    }
-
-    console.log('Checking out LibSass to', pkg.libsass);
-
-    var checkout = spawn('git', ['checkout', pkg.libsass], { cwd: './src/libsass' });
-    manageProcess(checkout, function(err) {
-      cb(err);
-    });
-  });
-}
-
-/**
- * installGitDependencies
- *
- * @param {Function} cb
- * @api private
- */
-
-function installGitDependencies(options, cb) {
-  var libsassPath = './src/libsass';
-
-  if (process.env.LIBSASS_EXT || options.libsassExt) {
-    cb();
-  } else if (fs.access) { // node 0.12+, iojs 1.0.0+
-    fs.access(libsassPath, fs.R_OK, function(err) {
-      err && err.code === 'ENOENT' ? initSubmodules(cb) : cb();
-    });
-  } else { // node < 0.12
-    fs.exists(libsassPath, function(exists) {
-      exists ? cb() : initSubmodules(cb);
-    });
-  }
-}
-
-/**
  * Build
  *
  * @param {Object} options
@@ -125,37 +56,30 @@ function installGitDependencies(options, cb) {
  */
 
 function build(options) {
-  installGitDependencies(options, function(err) {
-    if (err) {
-      console.error(err.message);
-      process.exit(1);
+  var args = [require.resolve(path.join('node-gyp', 'bin', 'node-gyp.js')), 'rebuild', '--verbose'].concat(
+    ['libsass_ext', 'libsass_cflags', 'libsass_ldflags', 'libsass_library'].map(function(subject) {
+      return ['--', subject, '=', process.env[subject.toUpperCase()] || ''].join('');
+    })).concat(options.args);
+
+  console.log('Building:', [process.execPath].concat(args).join(' '));
+
+  var proc = spawn(process.execPath, args, {
+    stdio: [0, 1, 2]
+  });
+
+  proc.on('exit', function(errorCode) {
+    if (!errorCode) {
+      afterBuild(options);
+      return;
     }
 
-    var args = [require.resolve(path.join('node-gyp', 'bin', 'node-gyp.js')), 'rebuild', '--verbose'].concat(
-      ['libsass_ext', 'libsass_cflags', 'libsass_ldflags', 'libsass_library'].map(function(subject) {
-        return ['--', subject, '=', process.env[subject.toUpperCase()] || ''].join('');
-      })).concat(options.args);
+    if (errorCode === 127 ) {
+      console.error('node-gyp not found!');
+    } else {
+      console.error('Build failed with error code:', errorCode);
+    }
 
-    console.log('Building:', [process.execPath].concat(args).join(' '));
-
-    var proc = spawn(process.execPath, args, {
-      stdio: [0, 1, 2]
-    });
-
-    proc.on('exit', function(errorCode) {
-      if (!errorCode) {
-        afterBuild(options);
-        return;
-      }
-
-      if (errorCode === 127 ) {
-        console.error('node-gyp not found!');
-      } else {
-        console.error('Build failed with error code:', errorCode);
-      }
-
-      process.exit(1);
-    });
+    process.exit(1);
   });
 }
 


### PR DESCRIPTION
The git submodule is removed as of #1850.

This was added by me in #874 to support node-sass being installed
as a gitish via GitHub rather than the npm registry. 

We publish the LibSass src to npm already so it should continue
to work as is.