### PR TITLE
Remove git sub module documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,7 @@ If this project is missing an API or command line flag that has been added to [l
 1. Ensure the `master` branch is up-to-date with: `git checkout master; git pull`
 2. Create a new Git branch and make your changes. `git checkout -b name-of-new-branch`
 3. Install all the node.js dependencies of node-sass with: `npm install`
-4. The Sass test spec and LibSass are Git submodules, so get their codebase with: `git submodule update --init`
-5. Ensure the tests pass with: `npm test`
+4. Ensure the tests pass with: `npm test`
 
 If the bug fix requires modifying any of the C++ files in the src/ directory, you'll need to re-build the bindings to libSass.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 ## Contributing
  * Fork the project.
  * Make your feature addition or bug fix.
- * Add documentation if necessary. 
+ * Add documentation if necessary.
  * Add tests for it. This is important so I don't break it in a future version unintentionally.
  * Send a pull request. Bonus points for topic branches.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,11 +42,6 @@ If the bug fix requires modifying any of the C++ files in the src/ directory, yo
 
 Alternatively, the `scripts/build.js` build script has several different command line flags that can be passed by running: `node scripts/build.js -[flag]`
 
-If the bug fix requires updating the version of libSass, you'll need to update its git submodule.
-
-1. Move into node-sass's libSass directory with: `cd src/libsass`
-2. Look for a new version of libSass with: `git tag` and check it out with: `git checkout [tag]`
-3. Then return to root of the node-sass repository and add the change to your feature branch.
 
 ## Reporting Sass compilation and syntax issues
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Used to determine how many digits after the decimal will be allowed. For instanc
 Type: `Boolean`
 Default: `false`
 
-`true` Enables the line number and file where a selector is defined to be emitted into the compiled CSS as a comment. Useful for debugging, especially when using imports and mixins. 
+`true` Enables the line number and file where a selector is defined to be emitted into the compiled CSS as a comment. Useful for debugging, especially when using imports and mixins.
 
 ### sourceMap
 Type: `Boolean | String | undefined`
@@ -351,7 +351,7 @@ var result = sass.renderSync({
   data: 'body{background:blue; a{color:black;}}',
   outputStyle: 'compressed',
   outFile: '/to/my/output.css',
-  sourceMap: true, // or an absolute or relative (to outFile) path 
+  sourceMap: true, // or an absolute or relative (to outFile) path
   importer: function(url, prev, done) {
     // url is the path in import as is, which LibSass encountered.
     // prev is the previously resolved path.
@@ -475,8 +475,8 @@ The interface for command-line usage is fairly simplistic at this stage, as seen
 Output will be sent to stdout if the `--output` flag is omitted.
 
 ### Usage
- `node-sass [options] <input> [output]`  
- Or:  
+ `node-sass [options] <input> [output]`
+ Or:
  `cat <input> | node-sass > output`
 
 Example:

--- a/README.md
+++ b/README.md
@@ -461,7 +461,6 @@ Check out the project:
 ```bash
 git clone --recursive https://github.com/sass/node-sass.git
 cd node-sass
-git submodule update --init --recursive
 npm install
 node scripts/build -f  # use -d switch for debug release
 # if succeeded, it will generate and move


### PR DESCRIPTION
As of #1850 we no long have a LibSass git submodule.