### PR TITLE
Remove process.sass

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -450,21 +450,3 @@ module.exports.types = binding.types;
 module.exports.TRUE = binding.types.Boolean.TRUE;
 module.exports.FALSE = binding.types.Boolean.FALSE;
 module.exports.NULL = binding.types.Null.NULL;
-
-/**
- * Polyfill the old API
- *
- * TODO: remove for 4.0
- */
-
-function processSassDeprecationMessage() {
-  console.log('Deprecation warning: `process.sass` is an undocumented internal that will be removed in future versions of Node Sass.');
-}
-
-process.sass = process.sass || {
-  get versionInfo()   { processSassDeprecationMessage(); return module.exports.info; },
-  get binaryName()    { processSassDeprecationMessage(); return sass.getBinaryName(); },
-  get binaryUrl()     { processSassDeprecationMessage(); return sass.getBinaryUrl(); },
-  get binaryPath()    { processSassDeprecationMessage(); return sass.getBinaryPath(); },
-  get getBinaryPath() { processSassDeprecationMessage(); return sass.getBinaryPath; },
-};


### PR DESCRIPTION
This is just #1730 rebased in v4.3.0.

We deprecated this previously to be removed in v4.