### PR TITLE
Use Visual Studio 2015 for Node 6+

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,13 +43,17 @@
       - nodejs_version: 4
       - nodejs_version: 5
       - nodejs_version: 6
+        GYP_MSVS_VERSION: 2015
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       - nodejs_version: 7
+        GYP_MSVS_VERSION: 2015
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
   install:
     - ps: Install-Product node $env:nodejs_version $env:platform
     - node --version
     - npm --version
-    - npm install --msvs_version=2013
+    - npm install
 
   test: off
 
@@ -111,16 +115,26 @@
     SKIP_SASS_BINARY_DOWNLOAD_FOR_CI: true
     matrix:
       - nodejs_version: 0.10
+        GYP_MSVS_VERSION: 2013
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       - nodejs_version: 0.12
+        GYP_MSVS_VERSION: 2013
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       - nodejs_version: 4
+        GYP_MSVS_VERSION: 2013
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       - nodejs_version: 6
+        GYP_MSVS_VERSION: 2015
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       - nodejs_version: 7
+        GYP_MSVS_VERSION: 2015
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
   install:
     - ps: Install-Product node $env:nodejs_version $env:platform
     - node --version
     - npm --version
-    - npm install --msvs_version=2013
+    - npm install
 
   test_script:
     - ps: set-location -path c:\projects\node_modules\node-sass


### PR DESCRIPTION
Node change to Visual Studio 2015 when Node 6 went to LTS.

See nodejs/node#7989
Fixes #1854