### PR TITLE
Make the watcher more responsive to child changes

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -268,7 +268,10 @@ function watch(options, emitter) {
 
     // Add children to watcher
     graph.visitDescendents(file, function(child) {
-      gaze.add(child);
+      if (watch.indexOf(child) === -1) {
+        watch.push(child);
+        gaze.add(child);
+      }
     });
     files.forEach(function(file) {
       if (path.basename(file)[0] !== '_') {


### PR DESCRIPTION
Watching for changes on files with lots of `@import`s had a
significant regression in responsiveness in #1745.

The regression was caused by calling `gaze.add` unnecessarily. We
only need to call `gaze.add` on files that aren't currently being
watched.

At the time I confirmed that calling `gaze.add` in files that were
being watched wouldn't result in a leak or multiple events being
fired. I however assumed calling `gaze.add` for already watched
files would be very cheap.

Fixes #1869