### PR TITLE
Fix npm rebuild

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -25,7 +25,7 @@ function foundBinariesList() {
 function missingBinaryFooter() {
   return [
     'This usually happens because your environment has changed since running `npm install`.',
-    'Run `npm rebuild node-sass` to build the binding for your current environment.',
+    'Run `npm rebuild node-sass --force` to build the binding for your current environment.',
   ].join('\n');
 }
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -93,7 +93,8 @@ function build(options) {
 function parseArgs(args) {
   var options = {
     arch: process.arch,
-    platform: process.platform
+    platform: process.platform,
+    force: process.env.npm_config_force === 'true',
   };
 
   options.args = args.filter(function(arg) {


### PR DESCRIPTION
Running `npm rebuild node-sass` as we instruct people, has been
noop for a while. I'm not entirely sure what has changed.

Debugging has revealed that running `rebuild` now just triggers the
`install` and `postinstall` scripts. The `build` script is no
longer run. This suggests something has changed in newer versions
of npm.

Since the `--force` flag is required to rebuild the binary I've
update the `build` script to take into account if `--force` was
passed to npm.