### PR TITLE
Install script should not write partially downloaded binaries

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -58,16 +58,17 @@ function download(url, dest, cb) {
         reportError(['HTTP error', response.statusCode, response.statusMessage].join(' '));
       } else {
         console.log('Download complete');
+
+        if (successful(response)) {
+          response.pipe(fs.createWriteStream(dest));
+        }
+
         cb();
       }
     })
     .on('response', function(response) {
       var length = parseInt(response.headers['content-length'], 10);
       var progress = log.newItem('', length);
-
-      if (successful(response)) {
-        response.pipe(fs.createWriteStream(dest));
-      }
 
       // The `progress` is true by default. However if it has not
       // been explicitly set it's `undefined` which is considered


### PR DESCRIPTION
Currently the binary download is streamed to disk once a 200 response
has been recieved. When an error occurs during the download a partially
downloaded binary is left on disk. Subsequent installs see the binary
and bail out of re-downloading it. Worse yet those subsequent installs
move the binary into the global cache so even removing node_modules
will not remove the broken binary.

With this patch the binary is only flushed to disk once it has been
fully downloaded.

Fixes #1882
Fixes #1888