### PR TITLE
Update request version to avoid npm warn

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "nan": "^2.3.2",
     "node-gyp": "^3.3.1",
     "npmlog": "^4.0.0",
-    "request": "^2.79.1",
+    "request": "^2.79.0",
     "sass-graph": "^2.1.1",
     "stdout-stream": "^1.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "nan": "^2.3.2",
     "node-gyp": "^3.3.1",
     "npmlog": "^4.0.0",
-    "request": "^2.61.0",
+    "request": "^2.79.1",
     "sass-graph": "^2.1.1",
     "stdout-stream": "^1.4.0"
   },


### PR DESCRIPTION
## Background
_request 2.78.0 uses deprecated node-uuid, it has been updated in version 2.79.0 to use uuid package, an unwanted warn is shown in the console when npm installing node-sass_
## Changes done
_bump request dependency version to 2.79.0_