### PR TITLE
Fix watching of CSS files to avoid infinite build cycle

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -274,7 +274,8 @@ function watch(options, emitter) {
       }
     });
     files.forEach(function(file) {
-      if (path.basename(file)[0] !== '_') {
+      var fileName = path.basename(file);
+      if (fileName[0] !== '_' && (!options.sameInputAsOutput || fileName.slice(-4) !== '.css')) {
         renderFile(file, options, emitter);
       }
     });
@@ -309,6 +310,8 @@ function run(options, emitter) {
     if (!isDirectory(options.output)) {
       emitter.emit('error', 'An output directory must be specified when compiling a directory');
     }
+
+    options.sameInputAsOutput = path.resolve(options.directory) === path.resolve(options.output);
   }
 
   if (options.sourceMapOriginal && options.directory && !isDirectory(options.sourceMapOriginal) && options.sourceMapOriginal !== 'true') {


### PR DESCRIPTION
Previously when the src and dest dirs were the same, whenever a CSS file changed (either manually or as the result of a build) it was recursively recompiled in an infinite loop, unless a build finished in less than
500ms (Gaze's default file watching debounce). Now, when the input and output dirs are the same, CSS files are treated like includes (files starting with an underscore) in that they are never built into CSS, but
they are watched in case they are included in a Sass file.

When the input and output dirs differ, functionality is unchanged.

I'm not sure the best way to go about writing tests for this. The infinite cycle only starts when builds takes longer than Gaze's default debounce timeout of 500ms (which is happening in a project I'm working on). A small logic bug in Gaze ([incorrect operator short-circuiting](https://github.com/shama/gaze/blob/8db2a1ec30b75167e96fc24902ae57c4a2fbba67/lib/gaze.js#L43)) prevents setting the timeout to 0 (poking into `node_modules` is how I demonstrated this issue while testing my changes). The one symptom you could test for is that if you modify a CSS file node-sass will process it and reformat it.

Currently, for reasons unknown to me, all the watch tests are being skipped (except the check that node-sass doesn't immediately exit). This causes me think the authors have been unable to get the watch tests passing. As someone unfamiliar with the project I would most likely be unable to get watch tests passing either.

This is related to #1758 (Inconsistent behavior when using directory input with --watch and without --watch). It would make the most sense to not compile CSS files at all (or at least make it consistent with and without --watch). As, @xzyfer points out though, changing it now could break builds that rely on node-sass compiling CSS files to another directory. However, this change only affects the scenario where the input directory is the same as the output directory, and therefore should not cause a problem.