### PR TITLE
Add Electron ABI versions

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -68,7 +68,10 @@ function getHumanNodeVersion(abi) {
     case 46: return 'Node.js 4.x';
     case 47: return 'Node.js 5.x';
     case 48: return 'Node.js 6.x';
+    case 49: return 'Electron 1.3.x';
+    case 50: return 'Electron 1.4.x';
     case 51: return 'Node.js 7.x';
+    case 53: return 'Electron 1.6.x';
     case 55: return 'Node.js 8.x';
     case 57: return 'Node.js 8.x';
     default: return false;


### PR DESCRIPTION
This adds the respective Electron ABI versions to `getHumanNodeVersion()`
to enable running `node-sass` under Electron where the ABI versions differ from Node's.