### PR TITLE
docs: Add global install instructions, change phrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,11 @@ node scripts/build -f  # use -d switch for debug release
 
 ## Command Line Interface
 
-The interface for command-line usage is fairly simplistic at this stage, as seen in the following usage section.
+To use `node-sass` from the CLI, you must install the package globally:
+
+```bash
+npm install --global node-sass
+```
 
 Output will be sent to stdout if the `--output` flag is omitted.
 


### PR DESCRIPTION
I have added the way to globally install node-sass from the CLI,
which isn't present in the README otherwise. I have also removed a
sentence which says that node-sass is simplistic. In both cases,
it is assumed that someone using the program knows how to use npm
to install command line packages, and that the user has some idea
about the level of complexity usual to an npm package. Both of
these assumptions are assumptions - my wording makes the package
more friendly to beginners by not assuming they know this.

tl;dr: just a small change to help new users.