### PR TITLE
Fixes tapdriver shebang

### DIFF
--- a/src/libsass/script/tap-driver
+++ b/src/libsass/script/tap-driver
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/env sh
 # Copyright (C) 2011-2013 Free Software Foundation, Inc.
 #
 # This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Adds the recommended shebang syntax -- the previous way breaks on sample AWS Elastic Beanstalk PHP environments.