### PR TITLE
[WIP] Make sure libsass headers are read first

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -35,8 +35,9 @@
         'GCC_ENABLE_CPP_EXCEPTIONS': 'NO',
         'MACOSX_DEPLOYMENT_TARGET': '10.7'
       },
-      'include_dirs': [
+      'include_dirs+': [
         '<!(node -e "require(\'nan\')")',
+        'src/libsass/include',
       ],
       'conditions': [
         ['libsass_ext == "" or libsass_ext == "no"', {

--- a/src/libsass.gyp
+++ b/src/libsass.gyp
@@ -68,7 +68,7 @@
         '-fexceptions',
         '-frtti',
       ],
-      'include_dirs': [ 'libsass/include' ],
+      'include_dirs+': [ 'libsass/include' ],
       'direct_dependent_settings': {
         'include_dirs': [ 'libsass/include' ],
       },


### PR DESCRIPTION
In the case libsass is installed system-wide
(e.g. the headers are in /usr/local/include) *and*
node requires reading headers from the same path
for the unbundled shared libraries like libuv,
make sure -I/usr/local/include will not take
precedence over our local bundles libsass headers.