### PR TITLE
use error.formatted at CLI error if it exists

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -105,7 +105,7 @@ module.exports = function(options, emitter) {
   };
 
   var error = function(error) {
-    emitter.emit('error', chalk.red(JSON.stringify(error, null, 2)));
+    emitter.emit('error', chalk.red(error.formatted || JSON.stringify(error, null, 2)));
   };
 
   var renderCallback = function(err, result) {

--- a/test/cli.js
+++ b/test/cli.js
@@ -762,7 +762,7 @@ describe('cli', function() {
       ]);
 
       bin.stderr.once('data', function(code) {
-        assert.equal(JSON.parse(code).message, 'doesn\'t exist!');
+        assert.ok(/doesn't exist!/.test(code.toString()));
         done();
       });
     });


### PR DESCRIPTION
Since it is difficult to read the error in JSON, I changed the `error.formatted` property to output error.
If there is no `formatted`, it will be output in JSON as before.

![](https://gyazo.com/53b67c73a6ce7cc25f49c4aee42c4feb/raw)