### PR TITLE
Remove Node 0.10 and 0.12 from CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,6 @@ jobs:
     - stage: platform-test
       node_js: "lts/argon"
       os: osx
-    - stage: platform-test
-      node_js: "0.12"
-      os: linux
-    - stage: platform-test
-      node_js: "0.10"
-      os: linux
 
 addons:
   apt:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Some users have reported issues installing on Ubuntu due to `node` being registe
 
 Compiling on Windows machines requires the [node-gyp prerequisites](https://github.com/nodejs/node-gyp#on-windows).
 
+If you're seeing the following error? Check out our [Troubleshooting guide](/TROUBLESHOOTING.md#installing-node-sass-4x-with-node--4).**
+
+```
+SyntaxError: Use of const in strict mode.
+```
+
 **Having installation troubles? Check out our [Troubleshooting guide](/TROUBLESHOOTING.md).**
 
 ## Usage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,24 +34,6 @@
   environment:
     SKIP_SASS_BINARY_DOWNLOAD_FOR_CI: true
     matrix:
-      - nodejs_version: 0.10
-        GYP_MSVS_VERSION: 2013
-        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-      - nodejs_version: 0.12
-        GYP_MSVS_VERSION: 2013
-        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-      - nodejs_version: 1.0
-        GYP_MSVS_VERSION: 2013
-        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-      - nodejs_version: 1
-        GYP_MSVS_VERSION: 2013
-        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-      - nodejs_version: 2
-        GYP_MSVS_VERSION: 2013
-        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-      - nodejs_version: 3
-        GYP_MSVS_VERSION: 2013
-        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       - nodejs_version: 4
         GYP_MSVS_VERSION: 2013
         APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
@@ -133,12 +115,6 @@
   environment:
     SKIP_SASS_BINARY_DOWNLOAD_FOR_CI: true
     matrix:
-      - nodejs_version: 0.10
-        GYP_MSVS_VERSION: 2013
-        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-      - nodejs_version: 0.12
-        GYP_MSVS_VERSION: 2013
-        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       - nodejs_version: 4
         GYP_MSVS_VERSION: 2013
         APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013


### PR DESCRIPTION
These will always fails now due to https://github.com/sass/node-sass/issues/2100. We manually verify support when building release binaries so there's no value in failing CI. It's scary to contributors.