### PR TITLE
Allow setting of SASS_BINARY_DIR without setting explicit binary name

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,6 +567,7 @@ Variable name    | .npmrc parameter | Process argument   | Value
 SASS_BINARY_NAME | sass_binary_name | --sass-binary-name | path
 SASS_BINARY_SITE | sass_binary_site | --sass-binary-site | URL
 SASS_BINARY_PATH | sass_binary_path | --sass-binary-path | path
+SASS_BINARY_DIR  | sass_binary_dir  | --sass-binary-dir  | path
 
 These parameters can be used as environment variable:
 

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -7,7 +7,7 @@ var eol = require('os').EOL,
   pkg = require('../package.json'),
   mkdir = require('mkdirp'),
   path = require('path'),
-  defaultBinaryPath = path.join(__dirname, '..', 'vendor'),
+  defaultBinaryDir = path.join(__dirname, '..', 'vendor'),
   trueCasePathSync = require('true-case-path');
 
 /**
@@ -126,7 +126,7 @@ function getHumanEnvironment(env) {
  * @api public
  */
 function getInstalledBinaries() {
-  return fs.readdirSync(defaultBinaryPath);
+  return fs.readdirSync(getBinaryDir());
 }
 
 /**
@@ -246,6 +246,38 @@ function getBinaryUrl() {
 }
 
 /**
+ * Get binary dir.
+ * If environment variable SASS_BINARY_DIR,
+ * .npmrc variable sass_binary_dir or
+ * process argument --sass-binary-dir is provided,
+ * select it by appending binary name, otherwise
+ * use default binary dir.
+ * Once the primary selection is made, check if
+ * callers wants to throw if file not exists before
+ * returning.
+ *
+ * @api public
+ */
+
+function getBinaryDir() {
+  var binaryDir;
+
+  if (getArgument('--sass-binary-dir')) {
+    binaryDir = getArgument('--sass-binary-dir');
+  } else if (process.env.SASS_BINARY_DIR) {
+    binaryDir = process.env.SASS_BINARY_DIR;
+  } else if (process.env.npm_config_sass_binary_dir) {
+    binaryDir = process.env.npm_config_sass_binary_dir;
+  } else if (pkg.nodeSassConfig && pkg.nodeSassConfig.binaryDir) {
+    binaryDir = pkg.nodeSassConfig.binaryDir;
+  } else {
+    binaryDir = defaultBinaryDir;
+  }
+
+  return binaryDir;
+}
+
+/**
  * Get binary path.
  * If environment variable SASS_BINARY_PATH,
  * .npmrc variable sass_binary_path or
@@ -271,7 +303,7 @@ function getBinaryPath() {
   } else if (pkg.nodeSassConfig && pkg.nodeSassConfig.binaryPath) {
     binaryPath = pkg.nodeSassConfig.binaryPath;
   } else {
-    binaryPath = path.join(defaultBinaryPath, getBinaryName().replace(/_(?=binding\.node)/, '/'));
+    binaryPath = path.join(getBinaryDir(), getBinaryName().replace(/_(?=binding\.node)/, '/'));
   }
 
   if (process.versions.modules < 46) {
@@ -415,6 +447,7 @@ function getPlatformVariant() {
 module.exports.hasBinary = hasBinary;
 module.exports.getBinaryUrl = getBinaryUrl;
 module.exports.getBinaryName = getBinaryName;
+module.exports.getBinaryDir = getBinaryDir;
 module.exports.getBinaryPath = getBinaryPath;
 module.exports.getBinaryCachePath = getBinaryCachePath;
 module.exports.getCachedBinary = getCachedBinary;

--- a/test/runtime.js
+++ b/test/runtime.js
@@ -83,6 +83,37 @@ describe('runtime parameters', function() {
       });
     });
 
+    describe('SASS_BINARY_DIR', function() {
+      beforeEach(function() {
+        process.argv.push('--sass-binary-dir', 'aaa');
+        process.env.SASS_BINARY_DIR = 'bbb';
+        process.env.npm_config_sass_binary_dir = 'ccc';
+        pkg.nodeSassConfig = { binaryDir: 'ddd' };
+      });
+
+      it('command line argument', function() {
+        assert.equal(sass.getBinaryDir(), 'aaa');
+      });
+
+      it('environment variable', function() {
+        process.argv = [];
+        assert.equal(sass.getBinaryDir(), 'bbb');
+      });
+
+      it('npm config variable', function() {
+        process.argv = [];
+        process.env.SASS_BINARY_DIR = null;
+        assert.equal(sass.getBinaryDir(), 'ccc');
+      });
+
+      it('package.json', function() {
+        process.argv = [];
+        process.env.SASS_BINARY_DIR = null;
+        process.env.npm_config_sass_binary_dir = null;
+        assert.equal(sass.getBinaryDir(), 'ddd');
+      });
+    });
+
     describe('SASS_BINARY_PATH', function() {
       beforeEach(function() {
         process.argv.push('--sass-binary-path', 'aaa_binding.node');


### PR DESCRIPTION
I'm at a company with people developing on multiple platforms behind a strict firewall. I want to host precompiled SASS bindings locally so setting SASS_BINARY_URL doesn't work for me. However I do not want to use SASS_BINARY_PATH because it requires giving explicit file name of the binding which doesn't work when some developers are on Macs, some on WIndows, and the whole project is compiled on Linux for production — it is quite a pain to set the full path as required in each environment, and as far as I know impossible within a static .npmrc file (.npmrc supports expansion of environment variables but I'd still need to set the SASS version, OS arch & Node Modules version).

Introducing: SASS_BINARY_DIR! Enables setting a directory where the binaries are stored but uses the default file name which SASS figures out by itself.

Also updated the `getBinaryPath` to use the new `getBinaryDir`.