### PR TITLE
docs: Update the Node version support message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # node-sass
 
-#### Supported Node.js versions 0.10, 0.12, 1, 2, 3, 4, 5, 6, 7 and 8.
+#### Supported Node.js versions vary by release, please consult the [releases page](https://github.com/sass/node-sass/releases)
 
 <table>
   <tr>


### PR DESCRIPTION
Pointing them to the release notes is safer since it will accurately reflect the support for that version of node-sass