### PR TITLE
Use trueCasePath only in Windows environments

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -277,7 +277,7 @@ function getBinaryPath() {
     return binaryPath;
   }
 
-  return trueCasePathSync(binaryPath) || binaryPath;
+  return /^win/.test(process.platform) ? trueCasePathSync(binaryPath) : binaryPath;
 }
 
 /**


### PR DESCRIPTION
During the install process of node-sass in [termux](https://github.com/termux/termux-app) under android I got an error like in this issue here #2157. 
Like @criess mentioned in his issue, the change for issue #2149 caused the problem of breaking installation in restricted environments like [termux](https://github.com/termux/termux-app) or protected cloud hosting environments. Because this change is mainly focused towards Windows installations I integrate the corresponding check to use it only if executed on Windows.