### PR TITLE
Normalize drive letter

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -295,24 +295,26 @@ function trueCasePathSync(fsPath) {
   // !! As of Node v4.1.1, a path starting with ../ is NOT resolved relative
   // !! to the current dir, and glob.sync() below then fails.
   // !! When in doubt, resolve with fs.realPathSync() *beforehand*.
-  var fsPathNormalized = path.normalize(fsPath)
+  var fsPathNormalized = path.normalize(fsPath);
 
   // OSX: HFS+ stores filenames in NFD (decomposed normal form) Unicode format,
   // so we must ensure that the input path is in that format first.
-  if (process.platform === 'darwin') fsPathNormalized = fsPathNormalized.normalize('NFD')
+  if (process.platform === 'darwin') {
+    fsPathNormalized = fsPathNormalized.normalize('NFD');
+  }
 
   // !! Windows: Curiously, the drive component mustn't be part of a glob,
   // !! otherwise glob.sync() will invariably match nothing.
   // !! Thus, we remove the drive component and instead pass it in as the 'cwd'
   // !! (working dir.) property below.
-  var pathRoot = path.parse(fsPathNormalized).root
-  var noDrivePath = fsPathNormalized.slice(Math.max(pathRoot.length - 1, 0))
+  var pathRoot = path.parse(fsPathNormalized).root;
+  var noDrivePath = fsPathNormalized.slice(Math.max(pathRoot.length - 1, 0));
 
   // Perform case-insensitive globbing (on Windows, relative to the drive /
   // network share) and return the 1st match, if any.
   // Fortunately, glob() with nocase case-corrects the input even if it is
   // a *literal* path.
-  return glob.sync(noDrivePath, { nocase: true, cwd: pathRoot.toLowerCase() })[0]
+  return glob.sync(noDrivePath, { nocase: true, cwd: pathRoot.toLowerCase() })[0];
 }
 
 /**

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -7,8 +7,8 @@ var eol = require('os').EOL,
   pkg = require('../package.json'),
   mkdir = require('mkdirp'),
   path = require('path'),
-  defaultBinaryPath = path.join(__dirname, '..', 'vendor'),
-  trueCasePathSync = require('true-case-path');
+  glob = require('glob'),
+  defaultBinaryPath = path.join(__dirname, '..', 'vendor');
 
 /**
  * Get the human readable name of the Platform that is running
@@ -282,6 +282,37 @@ function getBinaryPath() {
   } catch (e) {
     return binaryPath;
   }
+}
+
+/**
+ * Returns a normalized file path.
+ * Taken from `true-case-path` npm package, with additional change to normalize drive letter
+ * @param {string} File path
+ */
+function trueCasePathSync(fsPath) {
+
+  // Normalize the path so as to resolve . and .. components.
+  // !! As of Node v4.1.1, a path starting with ../ is NOT resolved relative
+  // !! to the current dir, and glob.sync() below then fails.
+  // !! When in doubt, resolve with fs.realPathSync() *beforehand*.
+  var fsPathNormalized = path.normalize(fsPath)
+
+  // OSX: HFS+ stores filenames in NFD (decomposed normal form) Unicode format,
+  // so we must ensure that the input path is in that format first.
+  if (process.platform === 'darwin') fsPathNormalized = fsPathNormalized.normalize('NFD')
+
+  // !! Windows: Curiously, the drive component mustn't be part of a glob,
+  // !! otherwise glob.sync() will invariably match nothing.
+  // !! Thus, we remove the drive component and instead pass it in as the 'cwd'
+  // !! (working dir.) property below.
+  var pathRoot = path.parse(fsPathNormalized).root
+  var noDrivePath = fsPathNormalized.slice(Math.max(pathRoot.length - 1, 0))
+
+  // Perform case-insensitive globbing (on Windows, relative to the drive /
+  // network share) and return the 1st match, if any.
+  // Fortunately, glob() with nocase case-corrects the input even if it is
+  // a *literal* path.
+  return glob.sync(noDrivePath, { nocase: true, cwd: pathRoot.toLowerCase() })[0]
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -70,8 +70,7 @@
     "npmlog": "^4.0.0",
     "request": "~2.79.0",
     "sass-graph": "^2.2.4",
-    "stdout-stream": "^1.4.0",
-    "true-case-path": "^1.0.2"
+    "stdout-stream": "^1.4.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.8",


### PR DESCRIPTION
This is a follow-up to #2149. 

I did not realize `true-case-path` did not normalize the drive letter, which can cause the same issues as described in #1895. The project does not seem to be maintained any longer, so I've removed the dependency and copied the code here with one small change to normalize the drive letter.