### PR TITLE
Use watcher removed function on deleted

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -263,7 +263,7 @@ function watch(options, emitter) {
   });
 
   gaze.on('deleted', function(file) {
-    handler(watcher.deleted(file));
+    handler(watcher.removed(file));
   });
 }
 


### PR DESCRIPTION
Updated the node-sass cli script to use the watcher removed function instead of the 'deleted' function which is non-existent.

Fixes #2248