### PR TITLE
Update request -> 2.80.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "nan": "^2.3.2",
     "node-gyp": "^3.3.1",
     "npmlog": "^4.0.0",
-    "request": "~2.79.0",
+    "request": "~2.80.0",
     "sass-graph": "^2.2.4",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^1.0.2"


### PR DESCRIPTION
request 2.79.0 depends on an old version of har-validator which depends on a package that no longer exists (pinkie-promise)

2.80.0 bumps the version of har-validator which no longer depends on pinkie-promise