### PR TITLE
npm install node-sass failed

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -69,7 +69,7 @@ npm install
 
 ### Which node runtime am I using?
 
-There are two primary node runtimes, Node.js and io.js, both of which are supported by node-sass. To determine which you are currenty using you first need to determine [which node runtime](#which-node-runtime-am-i-using-glossaryruntime) you are running.
+There are two primary node runtimes, Node.js and io.js, both of which are supported by node-sass. To determine which you are currently using you first need to determine [which node runtime](#which-node-runtime-am-i-using-glossaryruntime) you are running.
 
 ```
 node -v

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -277,7 +277,11 @@ function getBinaryPath() {
     return binaryPath;
   }
 
-  return trueCasePathSync(binaryPath) || binaryPath;
+  try {
+    return trueCasePathSync(binaryPath) || binaryPath;
+  } catch (e) {
+    return binaryPath;
+  }
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sass",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "libsass": "3.5.0.beta.2",
   "description": "Wrapper around libsass",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "nan": "^2.3.2",
     "node-gyp": "^3.3.1",
     "npmlog": "^4.0.0",
-    "request": "^2.79.0",
+    "request": "~2.79.0",
     "sass-graph": "^2.2.4",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sass",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "libsass": "3.5.0.beta.2",
   "description": "Wrapper around libsass",
   "license": "MIT",


### PR DESCRIPTION
C:\Users\jessryl.rabago>npm install node-sass

> node-sass@4.7.2 install C:\Users\jessryl.rabago\node_modules\node-sass
> node scripts/install.js

Downloading binary from https://github.com/sass/node-sass/releases/download/v4.7
.2/win32-x64-57_binding.node
Cannot download "https://github.com/sass/node-sass/releases/download/v4.7.2/win3
2-x64-57_binding.node":

tunneling socket could not be established, statusCode=403

Hint: If github.com is not accessible in your location
      try setting a proxy via HTTP_PROXY, e.g.

      export HTTP_PROXY=http://example.com:1234

or configure npm proxy via

      npm config set proxy http://example.com:8080

> node-sass@4.7.2 postinstall C:\Users\jessryl.rabago\node_modules\node-sass
> node scripts/build.js

Building: C:\Program Files\nodejs\node.exe C:\Users\jessryl.rabago\node_modules\
node-gyp\bin\node-gyp.js rebuild --verbose --libsass_ext= --libsass_cflags= --li
bsass_ldflags= --libsass_library=
gyp info it worked if it ends with ok
gyp verb cli [ 'C:\\Program Files\\nodejs\\node.exe',
gyp verb cli   'C:\\Users\\jessryl.rabago\\node_modules\\node-gyp\\bin\\node-gyp
.js',
gyp verb cli   'rebuild',
gyp verb cli   '--verbose',
gyp verb cli   '--libsass_ext=',
gyp verb cli   '--libsass_cflags=',
gyp verb cli   '--libsass_ldflags=',
gyp verb cli   '--libsass_library=' ]
gyp info using node-gyp@3.6.2
gyp info using node@8.9.4 | win32 | x64
gyp verb command rebuild []
gyp verb command clean []
gyp verb clean removing "build" directory
gyp verb command configure []
gyp verb check python checking for Python executable "python2.7" in the PATH
gyp verb `which` failed Error: not found: python2.7
gyp verb `which` failed     at getNotFoundError (C:\Users\jessryl.rabago\node_mo
dules\which\which.js:13:12)
gyp verb `which` failed     at F (C:\Users\jessryl.rabago\node_modules\which\whi
ch.js:68:19)
gyp verb `which` failed     at E (C:\Users\jessryl.rabago\node_modules\which\whi
ch.js:80:29)
gyp verb `which` failed     at C:\Users\jessryl.rabago\node_modules\which\which.
js:89:16
gyp verb `which` failed     at C:\Users\jessryl.rabago\node_modules\isexe\index.
js:42:5
gyp verb `which` failed     at C:\Users\jessryl.rabago\node_modules\isexe\window
s.js:36:5
gyp verb `which` failed     at FSReqWrap.oncomplete (fs.js:152:21)
gyp verb `which` failed  python2.7 { Error: not found: python2.7
gyp verb `which` failed     at getNotFoundError (C:\Users\jessryl.rabago\node_mo
dules\which\which.js:13:12)
gyp verb `which` failed     at F (C:\Users\jessryl.rabago\node_modules\which\whi
ch.js:68:19)
gyp verb `which` failed     at E (C:\Users\jessryl.rabago\node_modules\which\whi
ch.js:80:29)
gyp verb `which` failed     at C:\Users\jessryl.rabago\node_modules\which\which.
js:89:16
gyp verb `which` failed     at C:\Users\jessryl.rabago\node_modules\isexe\index.
js:42:5
gyp verb `which` failed     at C:\Users\jessryl.rabago\node_modules\isexe\window
s.js:36:5
gyp verb `which` failed     at FSReqWrap.oncomplete (fs.js:152:21)
gyp verb `which` failed   stack: 'Error: not found: python2.7\n    at getNotFoun
dError (C:\\Users\\jessryl.rabago\\node_modules\\which\\which.js:13:12)\n    at
F (C:\\Users\\jessryl.rabago\\node_modules\\which\\which.js:68:19)\n    at E (C:
\\Users\\jessryl.rabago\\node_modules\\which\\which.js:80:29)\n    at C:\\Users\
\jessryl.rabago\\node_modules\\which\\which.js:89:16\n    at C:\\Users\\jessryl.
rabago\\node_modules\\isexe\\index.js:42:5\n    at C:\\Users\\jessryl.rabago\\no
de_modules\\isexe\\windows.js:36:5\n    at FSReqWrap.oncomplete (fs.js:152:21)',

gyp verb `which` failed   code: 'ENOENT' }
gyp verb could not find "python2.7". checking python launcher
gyp verb could not find "python2.7". guessing location
gyp verb ensuring that file exists: C:\Python27\python.exe
gyp ERR! configure error
gyp ERR! stack Error: Can't find Python executable "python2.7", you can set the
PYTHON env variable.
gyp ERR! stack     at PythonFinder.failNoPython (C:\Users\jessryl.rabago\node_mo
dules\node-gyp\lib\configure.js:483:19)
gyp ERR! stack     at PythonFinder.<anonymous> (C:\Users\jessryl.rabago\node_mod
ules\node-gyp\lib\configure.js:508:16)
gyp ERR! stack     at C:\Users\jessryl.rabago\node_modules\graceful-fs\polyfills
.js:284:29
gyp ERR! stack     at FSReqWrap.oncomplete (fs.js:152:21)
gyp ERR! System Windows_NT 6.3.9600
gyp ERR! command "C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\jessryl.rabag
o\\node_modules\\node-gyp\\bin\\node-gyp.js" "rebuild" "--verbose" "--libsass_ex
t=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
gyp ERR! cwd C:\Users\jessryl.rabago\node_modules\node-sass
gyp ERR! node -v v8.9.4
gyp ERR! node-gyp -v v3.6.2
gyp ERR! not ok
Build failed with error code: 1
npm WARN rollback Rolling back glob@7.1.2 failed (this is probably harmless): EP
ERM: operation not permitted, scandir 'C:\Users\jessryl.rabago\node_modules\rimr
af\node_modules'
npm WARN enoent ENOENT: no such file or directory, open 'C:\Users\jessryl.rabago
\package.json'
npm WARN jessryl.rabago No description
npm WARN jessryl.rabago No repository field.
npm WARN jessryl.rabago No README data
npm WARN jessryl.rabago No license field.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! node-sass@4.7.2 postinstall: `node scripts/build.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the node-sass@4.7.2 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional log
ging output above.


Can you help me with this problem please.