### PR TITLE
Fixed compilation issue under certain config

### DIFF
--- a/src/libsass/src/utf8_string.cpp
+++ b/src/libsass/src/utf8_string.cpp
@@ -28,7 +28,7 @@ namespace Sass {
     size_t offset_at_position(const string& str, size_t position) {
       string::const_iterator it = str.begin();
       utf8::advance(it, position, str.end());
-      return distance(str.begin(), it);
+      return utf8::distance(str.begin(), it);
     }
 
     // function that returns number of bytes in a character at offset


### PR DESCRIPTION
The missing scope identifier could lead to unresolved `distance` function under certain compiler configuration. Adding the `utf8::` to fix this issue.