### PR TITLE
POC: Using WebAssembly build of libsass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ test/fixtures/watching-css-out-01
 test/fixtures/watching-css-out-02
 coverage
 package-lock.json
+libsass-asm.js
+libsass-wasm.js

--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -1,0 +1,75 @@
+/*tslint:disable:no-console*/
+
+/**
+ * Script to download libsass wasm binary from https://github.com/kwonoj/docker-libsass-wasm
+ */
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { exec, mkdir, rm } from 'shelljs';
+import { promisify } from 'util';
+//tslint:disable-next-line: no-require-imports no-var-requires
+const { config } = require('./package.json');
+
+// Package.json defines `libsass-version` under `config` section to find corresponding release version
+const version = config['libsass-version'];
+const readFile = promisify(fs.readFile);
+const writeFile = promisify(fs.writeFile);
+const asyncExec = promisify(exec);
+
+/**
+ * Generate sha512 checksum from given file.
+ */
+const calculateChecksumFromFile = async (filePath: string) =>
+  crypto
+    .createHash('sha512')
+    .update(await readFile(filePath))
+    .digest('hex');
+
+/**
+ * Get remote release checksum.
+ */
+const getRemoteChecksum = (url: string) => {
+  const { stdout } = exec(`wget -qO- ${url}.sha512`, { silent: true });
+  return (stdout as string).slice(0, (stdout as string).indexOf(' '));
+};
+
+/**
+ * Simple script to download compiled wasm binaries.
+ * wasm binary itself is being separately built & bumped up when libsass version changes,
+ * and this bootstarp script download corresponding version in package.json install time.
+ * Published package will ship with downloaded binary, download only occurs on prepare stage.
+ *
+ */
+(async () => {
+  const libPath = path.resolve('./lib');
+  const fileNames = ['libsass-asm.js', 'libsass-wasm.js'];
+
+  for (const fileName of fileNames) {
+    const localBinarypath = path.join(libPath, fileName);
+
+    const url = `https://github.com/kwonoj/docker-libsass-wasm/releases/download/${version}/${fileName}`;
+
+    //Create checksum validator
+    const remoteChecksum = getRemoteChecksum(url);
+    const validateBinary = async () => (await calculateChecksumFromFile(localBinarypath)) === remoteChecksum;
+    const isBinaryExists = () => fs.existsSync(localBinarypath);
+
+    if (isBinaryExists() && (await validateBinary())) {
+      continue;
+    }
+
+    console.log(`Downloading '${url}'`);
+
+    mkdir('-p', libPath);
+    rm('-rf', localBinarypath);
+
+    await asyncExec(`wget -q --directory-prefix=${libPath} ${url}`);
+    if (!isBinaryExists() || !await validateBinary()) {
+      throw new Error(`Downloaded binary checksum mismatch, cannot complete bootstrap`);
+    }
+  }
+
+  console.log(`Binary prepared, try to run 'node ./lib/loadModule.js' `);
+})();

--- a/lib/loadModule.js
+++ b/lib/loadModule.js
@@ -54,3 +54,59 @@ const wrapSassInterface = (cwrap) => ({
   '_sass_make_import_entry', \
   '_sass_import_set_error', \*/
 });
+
+/**
+ * Compile libsass wasm binary, create binding interfaces to compiled runtime.
+ */
+const loadLibSass = () => {
+  //if node.js supports native wasm, load wasm binary. otherwise, fall back to asm.js javascript.
+  const runtimeModule = require(`./libsass-${isWasmEnabled() ? 'wasm' : 'asm'}`);
+
+  /**
+   *  getModuleLoader returns a factory function to wasm binary.
+   *  when factory function is called, it internally compiles wasm binary into asmModule runtime, pass it to callback.
+   *  Callback creates javascript bindings to runtime module, includes interops around cwrapped function / pointer operations.
+   */
+  const moduleLoader = getModuleLoader((asmModule) => {
+    const { cwrap, Pointer_stringify, stackSave, stackRestore, stackAlloc, stringToUTF8 } = asmModule;
+    console.log(`${isWasmEnabled() ? 'wasm' : 'asm'} runtime successfully loaded`);
+
+    const {
+      version,
+      sass_make_data_context,
+      sass_data_context_get_context,
+      sass_compile_data_context,
+      sass_context_get_output_string
+    } = wrapSassInterface(cwrap);
+
+    const allocString = (value) => {
+      const len = (value.length << 2) + 1;
+      const ret = stackAlloc(len);
+      stringToUTF8(value, ret, len);
+      return ret;
+    };
+
+    /**
+     * Returning javascript module exports, corresponds to node-sass's index.js exports.
+     * (libsass_version / renderSync)
+     */
+    return {
+      libsass_version: () => {
+        const stack = stackSave();
+        const ret = Pointer_stringify(version());
+        stackRestore(stack);
+        return ret;
+      },
+      stackSave,
+      allocString,
+      Pointer_stringify,
+      stackRestore,
+      sass_make_data_context,
+      sass_data_context_get_context,
+      sass_compile_data_context,
+      sass_context_get_output_string
+    };
+  }, runtimeModule);
+
+  return moduleLoader();
+}

--- a/lib/loadModule.js
+++ b/lib/loadModule.js
@@ -149,3 +149,27 @@ const loadSass = () => loadLibSass().then((libsass) => {
     }
   }
 });
+
+/**
+ * Running poc demo, load module then compile data
+ */
+loadSass().then((sass) => {
+  console.log(sass.info);
+
+  const data = `$primaryColor: #eeffcc;
+
+    body {
+        background: $primaryColor;
+    }
+    `;
+
+  console.log(`\nCompiling\n`);
+  console.log(data);
+
+  const result = sass.renderSync({ data });
+
+  console.log(`Compiled into\n`);
+  console.log(result);
+}, (rej) => {
+  console.log(rej);
+});

--- a/lib/loadModule.js
+++ b/lib/loadModule.js
@@ -1,0 +1,56 @@
+/**
+ * wrap C interfaces of libsass into javascript function.
+ * Note: instead of embind with patching libsass, using cwrap to wrap C interface directly.
+ * it allows to leave libsass untouched.
+ */
+const wrapSassInterface = (cwrap) => ({
+  /* const char* libsass_version() */
+  version: cwrap('libsass_version', 'number'),
+  /* Sass_Data_Context* sass_make_data_context (char* source_string) */
+  sass_make_data_context: cwrap('sass_make_data_context', 'number', ['number']),
+  /*Sass_Context* sass_data_context_get_context (struct Sass_Data_Context* data_ctx) */
+  sass_data_context_get_context: cwrap('sass_data_context_get_context', 'number', ['number']),
+  /*int sass_compile_data_context (struct Sass_Data_Context* ctx) */
+  sass_compile_data_context: cwrap('sass_compile_data_context', 'number', ['number']),
+  /*const char* sass_context_get_output_string (struct Sass_Context* ctx) */
+  sass_context_get_output_string: cwrap('sass_context_get_output_string', 'number', ['number'])
+
+  //Rest of functions need to be wrapped to create feature parity to existing node-sass
+  /*
+  '_sass_make_file_context', \
+  '_sass_file_context_get_context', \
+  '_sass_context_get_options', \
+  '_sass_option_set_precision', \
+  '_sass_option_set_output_style', \
+  '_sass_option_set_source_comments', \
+  '_sass_option_set_source_map_embed', \
+  '_sass_option_set_source_map_contents', \
+  '_sass_option_set_omit_source_map_url', \
+  '_sass_option_set_indent', \
+  '_sass_option_set_linefeed', \
+  '_sass_option_set_input_path', \
+  '_sass_option_set_output_path', \
+  '_sass_option_set_plugin_path', \
+  '_sass_option_set_include_path', \
+  '_sass_option_set_source_map_file', \
+  '_sass_option_set_source_map_root', \
+  '_sass_option_set_c_functions', \
+  '_sass_make_importer_list', \
+  '_sass_make_importer', \
+  '_sass_importer_set_list_entry', \
+  '_sass_option_set_c_importers', \
+  '_sass_compile_file_context', \
+  '_sass_context_get_source_map_string', \
+  '_sass_context_get_included_files', \
+  '_sass_context_get_error_json', \
+  '_sass_context_get_error_message', \
+  '_sass_delete_file_context', \
+  '_sass_delete_data_context', \
+  '_sass_compiler_get_last_import', \
+  '_sass_import_get_abs_path', \
+  '_sass_compiler_get_context', \
+  '_sass_context_get_options', \
+  '_sass_make_import_list', \
+  '_sass_make_import_entry', \
+  '_sass_import_set_error', \*/
+});

--- a/lib/loadModule.js
+++ b/lib/loadModule.js
@@ -1,3 +1,6 @@
+const { getModuleLoader, isWasmEnabled } = require('emscripten-wasm-loader');
+const { EOL } = require('os');
+
 /**
  * wrap C interfaces of libsass into javascript function.
  * Note: instead of embind with patching libsass, using cwrap to wrap C interface directly.
@@ -110,3 +113,39 @@ const loadLibSass = () => {
 
   return moduleLoader();
 }
+
+/**
+ * Construct node-sass module from libsass binding interface.
+ *
+ */
+const loadSass = () => loadLibSass().then((libsass) => {
+  return {
+    info: [
+      ['node-sass', require('../package.json').version, '(Wrapper)', '[JavaScript]'].join('\t'),
+      ['libsass  ', libsass.libsass_version(), '(Sass Compiler)', '[C/C++]'].join('\t'),
+    ].join(EOL),
+    renderSync: (opts) => {
+      const {
+        Pointer_stringify,
+        stackSave,
+        stackRestore,
+        allocString,
+        sass_make_data_context,
+        sass_data_context_get_context,
+        sass_compile_data_context,
+        sass_context_get_output_string
+      } = libsass;
+
+      const stack = stackSave();
+
+      const data_ctx = sass_make_data_context(allocString(opts.data));
+      const ctx = sass_data_context_get_context(data_ctx);
+      const status = sass_compile_data_context(data_ctx);
+      const output = sass_context_get_output_string(data_ctx);
+      const outputString = Pointer_stringify(output);
+      stackRestore(stack);
+
+      return outputString;
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "license": "MIT",
   "bugs": "https://github.com/sass/node-sass/issues",
   "homepage": "https://github.com/sass/node-sass",
+  "config": {
+    "libsass-version": "3.5.0.beta.3-180118"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/sass/node-sass"
@@ -27,6 +30,7 @@
   },
   "gypfile": true,
   "scripts": {
+    "prepare": "node -r ts-node/register bootstrap.ts",
     "coverage": "node scripts/coverage.js",
     "install": "node scripts/install.js",
     "postinstall": "node scripts/build.js",
@@ -56,6 +60,7 @@
     "async-foreach": "^0.1.3",
     "chalk": "^1.1.1",
     "cross-spawn": "^3.0.0",
+    "emscripten-wasm-loader": "^1.0.0",
     "gaze": "^1.0.0",
     "get-stdin": "^4.0.1",
     "glob": "^7.0.3",
@@ -84,6 +89,9 @@
     "read-yaml": "^1.0.0",
     "rimraf": "^2.5.2",
     "sass-spec": "3.5.0-1",
+    "shelljs": "^0.8.0",
+    "ts-node": "^4.1.0",
+    "typescript": "^2.6.2",
     "unique-temp-dir": "^1.0.0"
   }
 }


### PR DESCRIPTION
**Not to be merged**. More of proof of concept to illustrate high-level codeflows with pros & cons, and roadmaps to make it happen. This PR aims to provide proof-of-concept implementation of #2011, replaces current native libsass module into WebAssembly based binary.

### How to run demo

`npm install && node ./lib/loadModule.js`. I haven't spend time to node.js version compatibility for `bootstrap.ts`, so ensure it doesn't emit error (and `wget` is available on shell too).

you can see version information, and simplest sass compilation result.

![image](https://user-images.githubusercontent.com/1210596/35137870-708dffb2-fca0-11e7-95a9-21807751c299.png)


### Code structure

Building `libsass` requires several native dependency & emsdk setup, but only necessary when need to bump up libsass itself. Instead of managing native build in single repo, this PR uses prebuilt binary via [docker-libsass-wasm](https://github.com/kwonoj/docker-libsass-wasm), preconfigured docker image generates specified libsass version of binary. In this PR, it builds latest beta 3.5.0.beta.3. `node-sass` uses tagged release from repo via `bootstrap` script, nothing more than just download binaries and put under correct location.

Prebuilt binary exposes C interface of `libsass` - in `loadModule.js`, `node-sass` creates corresponding bindings to C functions, wraps C interface to javascript functions with proper pointer interop, and finally exposes `loadSass` interface to compile wasm binary and build wrapped binding into `sass` module. In this PR, it exposes `sass.info` and naïve version of `renderSync` which only accepts data string.

### Pros & cons

Pros

- does not need native module anymore
- supports asm.js as fallback for node.js doesn't support native wasm

Cons

- Wasm compliation happens asynchronously, introduces breaking change interface `loadSass(): Promise<sass>` to prepare sass module correctly
- Basically this is rewriting of `node-sass`, dropping existing native bindings
- cabllback based async bindings (i.e `render`) is now won't be well supported, as it's basically not supported to create async fn via libuv queue. To provide interface level compatibility could trap out sync version into nexttick, but not ideal. (there are some experimental approach like `Emterpreter` but it is unsure it'll even work with libsass)

### Roadmap (if this is a thing to go)

- [ ] create wrapped interfaces / pointer interop for all necessary libsass interface
- [ ] migrate existing synchronous sass interface (`renderSync`, ...) 
- [ ] simple nexttick trapping for async interface (`render`, ...)
- [ ] evaluate empreter to replace ☝️ 
- [ ] migrate test cases to verify sanity
- [ ] explore possibility of creating correct async interface instead of trapping
- [ ] (good to have) run `libsass` test cases to wasm binary, to verify sanity of wasm binary itself