### PR TITLE
Fix TypeScript problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "main": "lib/index.js",
+  "main": "lib/index",
   "nodeSassConfig": {
     "binarySite": "https://github.com/sass/node-sass/releases/download"
   },


### PR DESCRIPTION
With the .js at the end of the filename, TypeScript was unable to find that declarations from @types/node-sass