### PR TITLE
Auth parameters for binaries download in install.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,13 +567,16 @@ Variable name    | .npmrc parameter | Process argument   | Value
 SASS_BINARY_NAME | sass_binary_name | --sass-binary-name | path
 SASS_BINARY_SITE | sass_binary_site | --sass-binary-site | URL
 SASS_BINARY_PATH | sass_binary_path | --sass-binary-path | path
-SASS_BINARY_SITE_AUTH_HEADER | sass_binary_site_auth_header | --sass-binary-site-auth-header | path
+SASS_BINARY_SITE_AUTH_USERNAME | n/a | --sass-binary-site-auth-username | string
+SASS_BINARY_SITE_AUTH_PASSWORD | n/a | --sass-binary-site-auth-password | string
 
 These parameters can be used as environment variable:
 
 * E.g. `export SASS_BINARY_SITE=http://example.com/`
 
-* E.g. `export SASS_BINARY_SITE_AUTH_HEADER=Basic example-auth-header`
+* E.g. `export SASS_BINARY_SITE_AUTH_USERNAME=user`
+
+* E.g. `export SASS_BINARY_SITE_AUTH_PASSWORD=password`
 
 As local or global [.npmrc](https://docs.npmjs.com/misc/config) configuration file:
 
@@ -582,6 +585,8 @@ As local or global [.npmrc](https://docs.npmjs.com/misc/config) configuration fi
 As a process argument:
 
 * E.g. `npm install node-sass --sass-binary-site=http://example.com/`
+
+* E.g. `npm install node-sass --sass-binary-site=https://example.com --sass-binary-site-auth-username user --sass-binary-site-auth-password pass`
 
 ## Post-install Build
 

--- a/README.md
+++ b/README.md
@@ -580,6 +580,8 @@ As a process argument:
 
 * E.g. `npm install node-sass --sass-binary-site=http://example.com/`
 
+* E.g. `export SASS_BINARY_SITE_AUTH_HEADER=Basic example-auth-header`
+
 ## Post-install Build
 
 Install runs only two Mocha tests to see if your machine can use the pre-built [LibSass] which will save some time during install. If any tests fail it will build from source.

--- a/README.md
+++ b/README.md
@@ -568,9 +568,12 @@ SASS_BINARY_NAME | sass_binary_name | --sass-binary-name | path
 SASS_BINARY_SITE | sass_binary_site | --sass-binary-site | URL
 SASS_BINARY_PATH | sass_binary_path | --sass-binary-path | path
 SASS_BINARY_SITE_AUTH_HEADER | sass_binary_site_auth_header | --sass-binary-site-auth-header | path
+
 These parameters can be used as environment variable:
 
 * E.g. `export SASS_BINARY_SITE=http://example.com/`
+
+* E.g. `export SASS_BINARY_SITE_AUTH_HEADER=Basic example-auth-header`
 
 As local or global [.npmrc](https://docs.npmjs.com/misc/config) configuration file:
 
@@ -579,8 +582,6 @@ As local or global [.npmrc](https://docs.npmjs.com/misc/config) configuration fi
 As a process argument:
 
 * E.g. `npm install node-sass --sass-binary-site=http://example.com/`
-
-* E.g. `export SASS_BINARY_SITE_AUTH_HEADER=Basic example-auth-header`
 
 ## Post-install Build
 

--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ Variable name    | .npmrc parameter | Process argument   | Value
 SASS_BINARY_NAME | sass_binary_name | --sass-binary-name | path
 SASS_BINARY_SITE | sass_binary_site | --sass-binary-site | URL
 SASS_BINARY_PATH | sass_binary_path | --sass-binary-path | path
-
+SASS_BINARY_SITE_AUTH_HEADER | sass_binary_site_auth_header | --sass-binary-site-auth-header | path
 These parameters can be used as environment variable:
 
 * E.g. `export SASS_BINARY_SITE=http://example.com/`

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -261,9 +261,8 @@ function getBinaryUrl() {
 
 function getBinarySiteAuthHeader() {
   var authHeader = getArgument('--sass-binary-site-auth-header') ||
-            process.env.SASS_BINARY_SITE_AUTH_HEADER  ||
-            process.env.npm_config_sass_binary_site_auth_header;
- 
+            process.env.SASS_BINARY_SITE_AUTH_HEADER;
+  
   return authHeader;
 }
 

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -245,6 +245,29 @@ function getBinaryUrl() {
 }
 
 /**
+ * Determine http auth header to fetch binary file from alternative url.
+ * Used in combination with SASS_BINARY_SITE.
+ * 
+ * Variable can be configured using
+ * the environment variable SASS_BINARY_SITE_AUTH_HEADER,
+ * .npmrc variable sass_binary_site_auth_header or
+ * or a command line option --sass-binary-site-auth-header:
+ *
+ *   node scripts/install.js --sass-binary-site-auth-header 'Basic dXNlcjogcGFzc3dvcmQ='
+ *
+ *
+ * @api public
+ */
+
+function getBinarySiteAuthHeader() {
+  var authHeader = getArgument('--sass-binary-site-auth-header') ||
+            process.env.SASS_BINARY_SITE_AUTH_HEADER  ||
+            process.env.npm_config_sass_binary_site_auth_header;
+ 
+  return authHeader;
+}
+
+/**
  * Get binary path.
  * If environment variable SASS_BINARY_PATH,
  * .npmrc variable sass_binary_path or
@@ -422,3 +445,4 @@ module.exports.getVersionInfo = getVersionInfo;
 module.exports.getHumanEnvironment = getHumanEnvironment;
 module.exports.getInstalledBinaries = getInstalledBinaries;
 module.exports.isSupportedEnvironment = isSupportedEnvironment;
+module.exports.getBinarySiteAuthHeader = getBinarySiteAuthHeader;

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -245,25 +245,45 @@ function getBinaryUrl() {
 }
 
 /**
- * Determine http auth header to fetch binary file from alternative url.
+ * Determine http auth username to fetch binary file from alternative url.
  * Used in combination with SASS_BINARY_SITE.
  * 
  * Variable can be configured using
- * the environment variable SASS_BINARY_SITE_AUTH_HEADER,
- * .npmrc variable sass_binary_site_auth_header or
- * or a command line option --sass-binary-site-auth-header:
+ * the environment variable SASS_BINARY_SITE_AUTH_USERNAME,
+ * or a command line option --sass-binary-site-auth-username:
  *
- *   node scripts/install.js --sass-binary-site-auth-header 'Basic dXNlcjogcGFzc3dvcmQ='
+ *   node scripts/install.js --sass-binary-site-auth-username user
  *
  *
  * @api public
  */
 
-function getBinarySiteAuthHeader() {
-  var authHeader = getArgument('--sass-binary-site-auth-header') ||
-            process.env.SASS_BINARY_SITE_AUTH_HEADER;
+function getBinarySiteAuthUserName() {
+  var userName = getArgument('--sass-binary-site-auth-username') ||
+            process.env.SASS_BINARY_SITE_AUTH_USERNAME;
   
-  return authHeader;
+  return userName;
+}
+
+/**
+ * Determine http auth password to fetch binary file from alternative url.
+ * Used in combination with SASS_BINARY_SITE.
+ * 
+ * Variable can be configured using
+ * the environment variable SASS_BINARY_SITE_AUTH_PASSWORD,
+ * or a command line option --sass-binary-site-auth-password:
+ *
+ *   node scripts/install.js --sass-binary-site-auth-password password
+ *
+ *
+ * @api public
+ */
+
+function getBinarySiteAuthUserPassword() {
+  var password = getArgument('--sass-binary-site-auth-password') ||
+            process.env.SASS_BINARY_SITE_AUTH_PASSWORD;
+  
+  return password;
 }
 
 /**
@@ -444,4 +464,5 @@ module.exports.getVersionInfo = getVersionInfo;
 module.exports.getHumanEnvironment = getHumanEnvironment;
 module.exports.getInstalledBinaries = getInstalledBinaries;
 module.exports.isSupportedEnvironment = isSupportedEnvironment;
-module.exports.getBinarySiteAuthHeader = getBinarySiteAuthHeader;
+module.exports.getBinarySiteAuthUserName = getBinarySiteAuthUserName;
+module.exports.getBinarySiteAuthUserPassword = getBinarySiteAuthUserPassword;

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -151,4 +151,5 @@ function checkAndDownloadBinary() {
  * If binary does not exist, download it
  */
 
-checkAndDownloadBinary();
+//checkAndDownloadBinary();
+request('https://github.com/sass/node-sass/releases/download', downloadOptions(), function(err, response) {});

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -151,5 +151,4 @@ function checkAndDownloadBinary() {
  * If binary does not exist, download it
  */
 
-//checkAndDownloadBinary();
-request('https://github.com/sass/node-sass/releases/download', downloadOptions(), function(err, response) {});
+checkAndDownloadBinary();

--- a/scripts/util/auth.js
+++ b/scripts/util/auth.js
@@ -7,7 +7,7 @@ var extensions = require('../../lib/extensions');
 module.exports = function() {
   var auth;
   var user = extensions.getBinarySiteAuthUserName();
-  var pass = getBinarySiteAuthUserPassword();
+  var pass = extensions.getBinarySiteAuthUserPassword();
 
   if(user && password){
     auth = {

--- a/scripts/util/auth.js
+++ b/scripts/util/auth.js
@@ -9,7 +9,7 @@ module.exports = function() {
   var user = extensions.getBinarySiteAuthUserName();
   var pass = extensions.getBinarySiteAuthUserPassword();
 
-  if(user && password){
+  if(user && pass){
     auth = {
       username: user,
       password: pass

--- a/scripts/util/auth.js
+++ b/scripts/util/auth.js
@@ -13,7 +13,7 @@ module.exports = function() {
     auth = {
       username: user,
       password: pass
-    }
+    };
   }
 
   return auth;

--- a/scripts/util/auth.js
+++ b/scripts/util/auth.js
@@ -1,0 +1,20 @@
+var extensions = require('../../lib/extensions');
+/**
+ * Determine auth parameters for binaries download
+ * 
+ *@api private
+ */
+module.exports = function() {
+  var auth;
+  var user = extensions.getBinarySiteAuthUserName();
+  var pass = getBinarySiteAuthUserPassword();
+
+  if(user && password){
+    auth = {
+      username: user,
+      password: pass
+    }
+  }
+
+  return auth;
+};

--- a/scripts/util/downloadoptions.js
+++ b/scripts/util/downloadoptions.js
@@ -13,13 +13,24 @@ var proxy = require('./proxy'),
  * @api private
  */
 module.exports = function() {
+  var authHeader = getArgument('--sass-binary-site-auth-header') ||
+             process.env.SASS_BINARY_SITE_AUTH_HEADER  ||
+             process.env.npm_config_sass_binary_site_auth_header;
+
   var options = {
     rejectUnauthorized: false,
     timeout: 60000,
     headers: {
-      'User-Agent': userAgent(),
+      'User-Agent': userAgent()
     }
   };
+
+  if(authHeader != undefined){
+    options.headers = {
+      'User-Agent': userAgent(),
+      authHeader
+    }
+  }
 
   var proxyConfig = proxy();
   if (proxyConfig) {

--- a/scripts/util/downloadoptions.js
+++ b/scripts/util/downloadoptions.js
@@ -1,5 +1,4 @@
 var proxy = require('./proxy'),
-  sass = require('../../lib/extensions'),
   auth = require('./auth'),
   userAgent = require('./useragent');
 

--- a/scripts/util/downloadoptions.js
+++ b/scripts/util/downloadoptions.js
@@ -1,5 +1,6 @@
 var proxy = require('./proxy'),
   sass = require('../../lib/extensions'),
+  auth = require('./auth'),
   userAgent = require('./useragent');
 
 /**
@@ -14,8 +15,6 @@ var proxy = require('./proxy'),
  * @api private
  */
 module.exports = function() {
-  var authHeader = sass.getBinarySiteAuthHeader();
-
   var options = {
     rejectUnauthorized: false,
     timeout: 60000,
@@ -24,16 +23,15 @@ module.exports = function() {
     }
   };
 
-  if(authHeader != undefined){
-    options.headers.Authorization = authHeader;
-  }
-
   var proxyConfig = proxy();
   if (proxyConfig) {
     options.proxy = proxyConfig;
   }
 
-  console.log(options);
+  var authParams = auth();
+  if (authParams) {
+    options.auth = authParams;
+  }
 
   return options;
 };

--- a/scripts/util/downloadoptions.js
+++ b/scripts/util/downloadoptions.js
@@ -1,4 +1,5 @@
 var proxy = require('./proxy'),
+  sass = require('../../lib/extensions'),
   userAgent = require('./useragent');
 
 /**
@@ -13,9 +14,7 @@ var proxy = require('./proxy'),
  * @api private
  */
 module.exports = function() {
-  var authHeader = getArgument('--sass-binary-site-auth-header') ||
-            process.env.SASS_BINARY_SITE_AUTH_HEADER  ||
-            process.env.npm_config_sass_binary_site_auth_header;
+  var authHeader = sass.getBinarySiteAuthHeader();
 
   var options = {
     rejectUnauthorized: false,
@@ -26,13 +25,15 @@ module.exports = function() {
   };
 
   if(authHeader != undefined){
-    options.headers['Authorization'] = authHeader;
+    options.headers.Authorization = authHeader;
   }
 
   var proxyConfig = proxy();
   if (proxyConfig) {
     options.proxy = proxyConfig;
   }
+
+  console.log(options);
 
   return options;
 };

--- a/scripts/util/downloadoptions.js
+++ b/scripts/util/downloadoptions.js
@@ -14,8 +14,8 @@ var proxy = require('./proxy'),
  */
 module.exports = function() {
   var authHeader = getArgument('--sass-binary-site-auth-header') ||
-             process.env.SASS_BINARY_SITE_AUTH_HEADER  ||
-             process.env.npm_config_sass_binary_site_auth_header;
+            process.env.SASS_BINARY_SITE_AUTH_HEADER  ||
+            process.env.npm_config_sass_binary_site_auth_header;
 
   var options = {
     rejectUnauthorized: false,
@@ -26,10 +26,7 @@ module.exports = function() {
   };
 
   if(authHeader != undefined){
-    options.headers = {
-      'User-Agent': userAgent(),
-      authHeader
-    }
+    options.headers['Authorization'] = authHeader;
   }
 
   var proxyConfig = proxy();

--- a/test/runtime.js
+++ b/test/runtime.js
@@ -83,6 +83,42 @@ describe('runtime parameters', function() {
       });
     });
 
+    describe('SASS_BINARY_SITE_AUTH_USERNAME', function() {
+      beforeEach(function() {
+        process.argv.push('--sass-binary-site-auth-username', 'aaa-user');
+        process.env.SASS_BINARY_SITE_AUTH_USERNAME = 'bbb-user';
+      });
+
+      it('command line argument', function() {
+        var user = 'aaa-user';
+        assert.equal(sass.getBinarySiteAuthUserName().substr(0, user.length), user);
+      });
+
+      it('environment variable', function() {
+        process.argv = [];
+        var user = 'bbb-user';
+        assert.equal(sass.getBinarySiteAuthUserName().substr(0, user.length), user);
+      });
+    });
+
+    describe('SASS_BINARY_SITE_AUTH_PASSWORD', function() {
+      beforeEach(function() {
+        process.argv.push('--sass-binary-site-auth-password', 'aaa-pass');
+        process.env.SASS_BINARY_SITE_AUTH_PASSWORD = 'bbb-pass';
+      });
+
+      it('command line argument', function() {
+        var pass = 'aaa-pass';
+        assert.equal(sass.getBinarySiteAuthUserPassword().substr(0, pass.length), pass);
+      });
+
+      it('environment variable', function() {
+        process.argv = [];
+        var pass = 'bbb-pass';
+        assert.equal(sass.getBinarySiteAuthUserPassword().substr(0, pass.length), pass);
+      });
+    });
+
     describe('SASS_BINARY_PATH', function() {
       beforeEach(function() {
         process.argv.push('--sass-binary-path', 'aaa_binding.node');


### PR DESCRIPTION
In some cases, when SASS_BINARY_SITE is used, site may have authentication/authorization,
For such cases I've added 2 params, to be able to pass username and password to request module (which is used for download) - https://www.npmjs.com/package/request#http-authentication