### PR TITLE
Add ARM CPU architectures

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -44,6 +44,11 @@ function getHumanArchitecture(arch) {
     case 'ia32': return '32-bit';
     case 'x86': return '32-bit';
     case 'x64': return '64-bit';
+    case 'armv7l': return '32-bit, ARM';
+    case 'armv7hf': return '32-bit, ARM';
+    case 'armv8': return '64-bit, ARM';
+    case 'aarch64': return '64-bit, ARM';
+    case 'arm64': return '64-bit, ARM';
     default: return false;
   }
 }


### PR DESCRIPTION
This adds armv7 and armv8 cpu architectures to `getHumanArchitecture()`
in order to support running node-sass on ARM.