### PR TITLE
build: Add back Appveyor 0.12-3

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,21 @@
   environment:
     SKIP_SASS_BINARY_DOWNLOAD_FOR_CI: true
     matrix:
+      - nodejs_version: 0.10
+        GYP_MSVS_VERSION: 2013
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      - nodejs_version: 0.12
+        GYP_MSVS_VERSION: 2013
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      - nodejs_version: 1
+        GYP_MSVS_VERSION: 2013
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      - nodejs_version: 2
+        GYP_MSVS_VERSION: 2013
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      - nodejs_version: 3
+        GYP_MSVS_VERSION: 2013
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       - nodejs_version: 4
         GYP_MSVS_VERSION: 2013
         APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013


### PR DESCRIPTION
We still want these till we officially drop the EOL Node versions.

Closes #2222 

I did a hacky Appveyor build to generate the release binaries here https://ci.appveyor.com/project/nschonni/node-sass/build/97