### PR TITLE
Update `request` to `2.83.0` at a minimum.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "nan": "^2.3.2",
     "node-gyp": "^3.3.1",
     "npmlog": "^4.0.0",
-    "request": "~2.79.0",
+    "request": "~2.83.0",
     "sass-graph": "^2.2.4",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^1.0.2"


### PR DESCRIPTION
This relates to Node Security Advisory CVE-2018-3728.

See https://nodesecurity.io/advisories/566 for more information.