### PR TITLE
Bump minimum nan@2.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lodash.mergewith": "^4.6.0",
     "meow": "^3.7.0",
     "mkdirp": "^0.5.1",
-    "nan": "^2.3.2",
+    "nan": "^2.9.2",
     "node-gyp": "^3.3.1",
     "npmlog": "^4.0.0",
     "request": "~2.79.0",


### PR DESCRIPTION
I ran into [an issue][1] compiling the iojs 3 binary on OSX. This
sound affect anyone in reality but just in case.

[1]: https://github.com/nodejs/nan/pull/728