### PR TITLE
Pre-empt support for Node 10

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -75,6 +75,7 @@ function getHumanNodeVersion(abi) {
     case 53: return 'Electron 1.6.x';
     case 57: return 'Node.js 8.x';
     case 59: return 'Node.js 9.x';
+    case 63: return 'Node.js 10.x';
     default: return false;
   }
 }


### PR DESCRIPTION
Lets try to avoid the rush of issues when Node 10 is released next
month.

Node 10 is currently version [`62`][1] but is expected to be
[`63`][2] before going stable. We need to pick one because of the
ABI breakage between 62 and 63.

If this bet pays off we save ourselves a bunch of time dealing with
installation issues, and avoiding a new release. If we're wrong it's
no different to any other major Node release.

[1]: https://github.com/nodejs/node/blob/97595739/src/node_version.h#L112
[2]: https://github.com/nodejs/node/pull/19201