### PR TITLE
Fix wrong binary encoding

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -51,7 +51,7 @@ function download(url, dest, cb) {
   console.log('Downloading binary from', url);
 
   try {
-    request(url, downloadOptions(), function(err, response) {
+    request(url, downloadOptions(), function(err, response, buffer) {
       if (err) {
         reportError(err);
       } else if (!successful(response)) {
@@ -60,10 +60,12 @@ function download(url, dest, cb) {
         console.log('Download complete');
 
         if (successful(response)) {
-          response.pipe(fs.createWriteStream(dest));
+          fs.createWriteStream(dest)
+            .on('error', cb)
+            .end(buffer, cb);
+        } else {
+          cb();
         }
-
-        cb();
       }
     })
     .on('response', function(response) {

--- a/scripts/util/downloadoptions.js
+++ b/scripts/util/downloadoptions.js
@@ -18,7 +18,8 @@ module.exports = function() {
     timeout: 60000,
     headers: {
       'User-Agent': userAgent(),
-    }
+    },
+    encoding: null,
   };
 
   var proxyConfig = proxy();

--- a/test/downloadoptions.js
+++ b/test/downloadoptions.js
@@ -12,7 +12,8 @@ describe('util', function() {
           timeout: 60000,
           headers: {
             'User-Agent': ua(),
-          }
+          },
+          encoding: null,
         };
 
         assert.deepEqual(opts(), expected);
@@ -37,7 +38,8 @@ describe('util', function() {
           timeout: 60000,
           headers: {
             'User-Agent': ua(),
-          }
+          },
+          encoding: null,
         };
 
         assert.deepEqual(opts(), expected);
@@ -61,7 +63,8 @@ describe('util', function() {
           timeout: 60000,
           headers: {
             'User-Agent': ua(),
-          }
+          },
+          encoding: null,
         };
 
         assert.deepEqual(opts(), expected);


### PR DESCRIPTION
Due to #1912 we were writing binaries to disk with the encoding.
We need to do some additional juggling when dealing with binary
data.