### PR TITLE
Bump "request" to 2.85.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "nan": "^2.9.2",
     "node-gyp": "^3.3.1",
     "npmlog": "^4.0.0",
-    "request": "~2.79.0",
+    "request": "~2.85.0",
     "sass-graph": "^2.2.4",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "object-merge": "^2.5.1",
     "read-yaml": "^1.0.0",
     "rimraf": "^2.5.2",
-    "sass-spec": "^3.5.0",
+    "sass-spec": "^3.5.1",
     "unique-temp-dir": "^1.0.0"
   }
 }

--- a/src/libsass/docs/implementations.md
+++ b/src/libsass/docs/implementations.md
@@ -3,6 +3,9 @@ There are several implementations of `libsass` for a variety of languages. Here 
 ### C
 * [sassc](https://github.com/hcatlin/sassc)
 
+### Crystal
+* [sass.cr](https://github.com/straight-shoota/sass.cr)
+
 ### Elixir
 * [sass.ex](https://github.com/scottdavis/sass.ex)
 

--- a/src/libsass/src/check_nesting.cpp
+++ b/src/libsass/src/check_nesting.cpp
@@ -108,9 +108,7 @@ namespace Sass {
     this->visit_children(i);
 
     if (Block_Ptr b = Cast<Block>(i->alternative())) {
-      for (auto n : i->alternative()->elements()) {
-        n->perform(this);
-      }
+      for (auto n : b->elements()) n->perform(this);
     }
 
     return i;

--- a/src/libsass/src/context.cpp
+++ b/src/libsass/src/context.cpp
@@ -653,8 +653,11 @@ namespace Sass {
     Expand expand(*this, &global, &backtrace);
     Cssize cssize(*this, &backtrace);
     CheckNesting check_nesting;
-    // check nesting
-    check_nesting(root);
+    // check nesting in all files
+    for (auto sheet : sheets) {
+      auto styles = sheet.second;
+      check_nesting(styles.root);
+    }
     // expand and eval the tree
     root = expand(root);
     // check nesting

--- a/src/libsass/src/eval.cpp
+++ b/src/libsass/src/eval.cpp
@@ -1562,6 +1562,7 @@ namespace Sass {
       v->value(ops[op](lv, rn.value() * f));
     }
 
+    v->reduce();
     v->pstate(pstate);
     return v.detach();
   }

--- a/src/libsass/src/functions.cpp
+++ b/src/libsass/src/functions.cpp
@@ -102,8 +102,6 @@ namespace Sass {
 
   namespace Functions {
 
-    static Number tmpnr(ParserState("[FN]"), 0);
-
     inline void handle_utf8_error (const ParserState& pstate, Backtrace* backtrace)
     {
       try {
@@ -159,7 +157,7 @@ namespace Sass {
     {
       // Minimal error handling -- the expectation is that built-ins will be written correctly!
       Number_Ptr val = get_arg<Number>(argname, env, sig, pstate, backtrace);
-      tmpnr = val;
+      Number tmpnr(val);
       tmpnr.reduce();
       double v = tmpnr.value();
       if (!(lo <= v && v <= hi)) {
@@ -175,7 +173,7 @@ namespace Sass {
     {
       // Minimal error handling -- the expectation is that built-ins will be written correctly!
       Number_Ptr val = get_arg<Number>(argname, env, sig, pstate, backtrace);
-      tmpnr = val;
+      Number tmpnr(val);
       tmpnr.reduce();
       return tmpnr;
     }
@@ -193,7 +191,7 @@ namespace Sass {
     {
       // Minimal error handling -- the expectation is that built-ins will be written correctly!
       Number_Ptr val = get_arg<Number>(argname, env, sig, pstate, backtrace);
-      tmpnr = val;
+      Number tmpnr(val);
       tmpnr.reduce();
       /*
       if (tmpnr.unit() == "%") {
@@ -210,7 +208,7 @@ namespace Sass {
     {
       // Minimal error handling -- the expectation is that built-ins will be written correctly!
       Number_Ptr val = get_arg<Number>(argname, env, sig, pstate, backtrace);
-      tmpnr = val;
+      Number tmpnr(val);
       tmpnr.reduce();
       return tmpnr.value();
     }
@@ -218,7 +216,8 @@ namespace Sass {
     double color_num(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtrace* backtrace)
     {
       Number_Ptr val = get_arg<Number>(argname, env, sig, pstate, backtrace);
-      tmpnr = val; tmpnr.reduce();
+      Number tmpnr(val);
+      tmpnr.reduce();
       if (tmpnr.unit() == "%") {
         return std::min(std::max(tmpnr.value() * 255 / 100.0, 0.0), 255.0);
       } else {
@@ -229,7 +228,8 @@ namespace Sass {
 
     inline double alpha_num(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtrace* backtrace) {
       Number_Ptr val = get_arg<Number>(argname, env, sig, pstate, backtrace);
-      tmpnr = val; tmpnr.reduce();
+      Number tmpnr(val);
+      tmpnr.reduce();
       if (tmpnr.unit() == "%") {
         return std::min(std::max(tmpnr.value(), 0.0), 100.0);
       } else {


### PR DESCRIPTION
To fix retirejs warning about low priority security vulnerability in hoek@2.16.13 (referenced via request@2.79.0 -> hawk@3.1.3 -> sntp@1.0.9 -> hoek@2.16.13).

The latest Request, v2.85.0 references hawk@6.0.2 -> sntp@2.1.0 -> hoek@4.2.1, which does not have any vulnerabilities.