### PR TITLE
[v5] Indicate the supported Node.js version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "http://andrew.github.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": "^6.9 || ^8.9 || ^9 || ^10"
   },
   "main": "lib/index.js",
   "nodeSassConfig": {


### PR DESCRIPTION
I based the range on what's indicated in `.travis.yml` but since Travis always defaults to the newest release in each series a higher minor could be selected as well.

Especially Node.js 4.5 might be a good pick since it's the first release to support `Buffer.from`, `Buffer.alloc` and `Buffer.allocUnsafe`.

In #2111 I found this mention in the summary:

> Moving forward we'll only be actively supporting active LTS and current Node versions. In practical terms this means Node 6+.

But it's not currently reflected in the Travis config.

Relates to #2312 