### PR TITLE
Update request package version for security

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "nan": "^2.10.0",
     "node-gyp": "^3.3.1",
     "npmlog": "^4.0.0",
-    "request": "~2.79.0",
+    "request": "~2.85.0",
     "sass-graph": "^2.2.4",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^1.0.2"


### PR DESCRIPTION
Hi,

I am using the latest version of node-sass, but it uses very old version of request package. It contains several old pacages that have security halls. Updating to the latest request@2.85.0 fixes it completely.

The following is the result of "snyk test" command result:

```
✗ Low severity vulnerability found on hoek@2.16.3
- desc: Prototype Pollution
- info: https://snyk.io/vuln/npm:hoek:20180212
- from: my-project@1.0.0 > node-sass@4.8.3 > request@2.79.0 > hawk@3.1.3 > hoek@2.16.3
No direct dependency upgrade can address this issue.
Run `snyk wizard` to explore remediation options.

✗ Low severity vulnerability found on hoek@2.16.3
- desc: Prototype Pollution
- info: https://snyk.io/vuln/npm:hoek:20180212
- from: my-project@1.0.0 > node-sass@4.8.3 > request@2.79.0 > hawk@3.1.3 > boom@2.10.1 > hoek@2.16.3
No direct dependency upgrade can address this issue.
Run `snyk wizard` to explore remediation options.

✗ Low severity vulnerability found on hoek@2.16.3
- desc: Prototype Pollution
- info: https://snyk.io/vuln/npm:hoek:20180212
- from: my-project@1.0.0 > node-sass@4.8.3 > request@2.79.0 > hawk@3.1.3 > sntp@1.0.9 > hoek@2.16.3
No direct dependency upgrade can address this issue.
Run `snyk wizard` to explore remediation options.

✗ Low severity vulnerability found on hoek@2.16.3
- desc: Prototype Pollution
- info: https://snyk.io/vuln/npm:hoek:20180212
- from: my-project@1.0.0 > node-sass@4.8.3 > request@2.79.0 > hawk@3.1.3 > cryptiles@2.0.5 > boom@2.10.1 > hoek@2.16.3
No direct dependency upgrade can address this issue.
Run `snyk wizard` to explore remediation options.

✗ Medium severity vulnerability found on tunnel-agent@0.4.3
- desc: Uninitialized Memory Exposure
- info: https://snyk.io/vuln/npm:tunnel-agent:20170305
- from: my-project@1.0.0 > node-sass@4.8.3 > request@2.79.0 > tunnel-agent@0.4.3
No direct dependency upgrade can address this issue.
Run `snyk wizard` to explore remediation options.
```