### PR TITLE
Fix Node 10 check

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -75,7 +75,7 @@ function getHumanNodeVersion(abi) {
     case 53: return 'Electron 1.6.x';
     case 57: return 'Node.js 8.x';
     case 59: return 'Node.js 9.x';
-    case 63: return 'Node.js 10.x';
+    case 64: return 'Node.js 10.x';
     default: return false;
   }
 }


### PR DESCRIPTION
#2274 tried preempt Node 10 module version, but missed the mark.

Node 10 is now in RC as `64`. I've confirmed Node Sass compiles and runs with OSX.