### PR TITLE
Bump LibSass@3.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-sass",
   "version": "4.9.0",
-  "libsass": "3.5.3",
+  "libsass": "3.5.4",
   "description": "Wrapper around libsass",
   "license": "MIT",
   "bugs": "https://github.com/sass/node-sass/issues",
@@ -83,7 +83,7 @@
     "object-merge": "^2.5.1",
     "read-yaml": "^1.0.0",
     "rimraf": "^2.5.2",
-    "sass-spec": "3.5.3",
+    "sass-spec": "3.5.4-1",
     "unique-temp-dir": "^1.0.0"
   }
 }

--- a/src/libsass/src/sass2scss.cpp
+++ b/src/libsass/src/sass2scss.cpp
@@ -154,21 +154,6 @@ namespace Sass
 
 	}
 
-	static size_t findFirstCharacter (std::string& sass, size_t pos)
-	{
-		return sass.find_first_not_of(SASS2SCSS_FIND_WHITESPACE, pos);
-	}
-
-	static size_t findLastCharacter (std::string& sass, size_t pos)
-	{
-		return sass.find_last_not_of(SASS2SCSS_FIND_WHITESPACE, pos);
-	}
-
-	static bool isUrl (std::string& sass, size_t pos)
-	{
-		return sass[pos] == 'u' && sass[pos+1] == 'r' && sass[pos+2] == 'l' && sass[pos+3] == '(';
-	}
-
 	// check if there is some char data
 	// will ignore everything in comments
 	static bool hasCharData (std::string& sass)
@@ -602,7 +587,6 @@ namespace Sass
 				sass.substr(pos_left, 5) == "@warn" ||
 				sass.substr(pos_left, 6) == "@debug" ||
 				sass.substr(pos_left, 6) == "@error" ||
-				sass.substr(pos_left, 6) == "@value" ||
 				sass.substr(pos_left, 8) == "@charset" ||
 				sass.substr(pos_left, 10) == "@namespace"
 			) { sass = indent + sass.substr(pos_left); }
@@ -622,38 +606,23 @@ namespace Sass
 			{
 				// get positions for the actual import url
 				size_t pos_import = sass.find_first_of(SASS2SCSS_FIND_WHITESPACE, pos_left + 7);
-				size_t pos = sass.find_first_not_of(SASS2SCSS_FIND_WHITESPACE, pos_import);
-				size_t start = pos;
-				bool in_dqstr = false;
-				bool in_sqstr = false;
-				bool is_escaped = false;
-				do {
-					if (is_escaped) {
-						is_escaped = false;
-					}
-					else if (sass[pos] == '\\') {
-						is_escaped = true;
-					}
-					else if (sass[pos] == '"') {
-						if (!in_sqstr) in_dqstr = ! in_dqstr;
-					}
-					else if (sass[pos] == '\'') {
-						if (!in_dqstr) in_sqstr = ! in_sqstr;
-					}
-					else if (in_dqstr || in_sqstr) {
-						// skip over quoted stuff
-					}
-					else if (sass[pos] == ',' || sass[pos] == 0) {
-						if (sass[start] != '"' && sass[start] != '\'' && !isUrl(sass, start)) {
-							size_t end = findLastCharacter(sass, pos - 1) + 1;
-							sass = sass.replace(end, 0, "\"");
-							sass = sass.replace(start, 0, "\"");
-							pos += 2;
+				size_t pos_quote = sass.find_first_not_of(SASS2SCSS_FIND_WHITESPACE, pos_import);
+				// leave proper urls untouched
+				if (sass.substr(pos_quote, 4) != "url(")
+				{
+					// check if the url appears to be already quoted
+					if (sass.substr(pos_quote, 1) != "\"" && sass.substr(pos_quote, 1) != "\'")
+					{
+						// get position of the last char on the line
+						size_t pos_end = sass.find_last_not_of(SASS2SCSS_FIND_WHITESPACE);
+						// assertion check for valid result
+						if (pos_end != std::string::npos)
+						{
+							// add quotes around the full line after the import statement
+							sass = sass.substr(0, pos_quote) + "\"" + sass.substr(pos_quote, pos_end - pos_quote + 1) + "\"";
 						}
-						start = findFirstCharacter(sass, pos + 1);
 					}
 				}
-				while (sass[pos++] != 0);
 
 			}
 			else if (


### PR DESCRIPTION
Bump LibSass@3.5.4 to address some regressions in LibSass@3.5.3.

https://github.com/sass/libsass/releases/tag/3.5.4

Lock to sass-spec@3.5.4-1 because of specs that depend on features
reverted in 3.5.4.