### PR TITLE
require request 2.85.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "nan": "^2.10.0",
     "node-gyp": "^3.3.1",
     "npmlog": "^4.0.0",
-    "request": "~2.79.0",
+    "request": "~2.85.1",
     "sass-graph": "^2.2.4",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^1.0.2"


### PR DESCRIPTION
request 2.85.1 requires hawk 6.0.2, which requires boom 4.x.x, which requires hoek 4.x.x. (hoek 2.16.3 has a security vulnerability).