### PR TITLE
node-sass 4.9.0 (bumping libsass) caused a regression

### DIFF
--- a/test/api.js
+++ b/test/api.js
@@ -1992,4 +1992,38 @@ describe('api', function() {
       done();
     });
   });
+
+  describe('strange error', function() {
+    it('should work', function() {
+      var result = sass.renderSync({
+        data: [
+          '@function get-color($colorName, $opacity: 1) {',
+          '$map: build-map();',
+          '$color: map-get($map, black);',
+
+          '@if $color == null {',
+          '  @error "Color `#{$colorName}` not found in map #{$map}";',
+          '}',
+
+          '@return $color;',
+          '}',
+
+          '.foo { background: get-color(black); }'
+        ].join('\n'),
+
+        functions: {
+          'build-map()': function() {
+            var map = new sass.types.Map(1);
+
+            map.setKey(0, sass.types.String('black'));
+            map.setValue(0, sass.types.Color(0, 0, 0));
+
+            return map;
+          }
+        }
+      });
+
+      assert.equal(result.css.toString().replace('\n ', '').trim(), '.foo { background: black; }');
+    });
+  });
 });


### PR DESCRIPTION
I have included a failing test, and bisect suggests the following commit:

https://github.com/sass/node-sass/commit/7ec14dff2087266357146598cd267f4133f3fdf6

```diff
7ec14dff2087266357146598cd267f4133f3fdf6 is the first bad commit
commit 7ec14dff2087266357146598cd267f4133f3fdf6
Author: xzyfer <xzyfer@gmail.com>
Date:   Wed Apr 25 01:56:30 2018 +1000

    Bump LibSass@3.5.3

:100644 100644 466e3ab638ea801dbb880d5b9b9de1263d0cf3bc 5c5972278855bc49f19c807f4f4343d9a6ca9b94 M      package.json
:040000 040000 f171af209130ad6c3528fb25fd65ea5cc952dc30 359c2cc77e49902cefae961592aba1270a1a144a M      src
```

 Bisect log:

```sh
git bisect start
# good: [31abf973bd20d45c253d45f421fd8b3bcce0f92f] failure
git bisect good 31abf973bd20d45c253d45f421fd8b3bcce0f92f
# bad: [ac67c7ad14afc6545b193802d8d9271c3335fc84] failure
git bisect bad ac67c7ad14afc6545b193802d8d9271c3335fc84
# bad: [ac67c7ad14afc6545b193802d8d9271c3335fc84] failure
git bisect bad ac67c7ad14afc6545b193802d8d9271c3335fc84
# good: [b2df434a02c10b2263d3879fe75dfbed4460b75f] 4.8.3
git bisect good b2df434a02c10b2263d3879fe75dfbed4460b75f
# good: [5e10a9b9df87db448374bd7e78ffb3ba2699aff6] 4.9.0
git bisect good 5e10a9b9df87db448374bd7e78ffb3ba2699aff6
# bad: [a124e9d42e1f5bdb0a96fca78435c889e6e2b41f] Add Node 10 to CI
git bisect bad a124e9d42e1f5bdb0a96fca78435c889e6e2b41f
# bad: [7ec14dff2087266357146598cd267f4133f3fdf6] Bump LibSass@3.5.3
git bisect bad 7ec14dff2087266357146598cd267f4133f3fdf6
# good: [eb5ad0a7b8b98a35d752c3dea3573c5fb491be8e] Revert "Bump LibSass@3.5.3 (#2342)"
git bisect good eb5ad0a7b8b98a35d752c3dea3573c5fb491be8e
# first bad commit: [7ec14dff2087266357146598cd267f4133f3fdf6] Bump LibSass@3.5.3
```