### PR TITLE
Updated links to absolute path instead of relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ Some users have reported issues installing on Ubuntu due to `node` being registe
 
 Compiling on Windows machines requires the [node-gyp prerequisites](https://github.com/nodejs/node-gyp#on-windows).
 
-Are you seeing the following error? Check out our [Troubleshooting guide](/TROUBLESHOOTING.md#installing-node-sass-4x-with-node--4).**
+Are you seeing the following error? Check out our [Troubleshooting guide](https://github.com/sass/node-sass/blob/master/TROUBLESHOOTING.md#installing-node-sass-4x-with-node--4).**
 
 ```
 SyntaxError: Use of const in strict mode.
 ```
 
-**Having installation troubles? Check out our [Troubleshooting guide](/TROUBLESHOOTING.md).**
+**Having installation troubles? Check out our [Troubleshooting guide](https://github.com/sass/node-sass/blob/master/TROUBLESHOOTING.md).**
 
 ### Install from mirror in China
 


### PR DESCRIPTION
solves #2370 
with relative path to troubleshoot guide, npm was unable to direct to correct page. Now its corrected using absolute path.

