### PR TITLE
docs: Clarify --source-map flag. Closes #1026.

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -47,7 +47,7 @@ var cli = meow({
     '  --indent-width             Indent width; number of spaces or tabs (maximum value: 10)',
     '  --linefeed                 Linefeed style (cr | crlf | lf | lfcr)',
     '  --source-comments          Include debug info in output',
-    '  --source-map               Emit source map',
+    '  --source-map               Emit source map (boolean, or path to output .map file)',
     '  --source-map-contents      Embed include contents in map',
     '  --source-map-embed         Embed sourceMappingUrl as data URI',
     '  --source-map-root          Base path, will be emitted in source-map as is',


### PR DESCRIPTION
It is not clear from the `--help` docs that `--source-map` requires a boolean or path. Passing the flag alone results in a TypeError. There's an argument to be made that passing the flag alone should imply `true`, or at the very least it should fail with a helpful error, not a cryptic TypeError. For now, this PR fixes the --help docs so that they match the README.

<!--

**Do not bump the Request package, it breaks old Node compatiblity. It is used for downloading the binaries.**

Thanks for contibuting otherwise!
-->
