### PR TITLE
Split issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,15 +3,7 @@
 Before opening an issue:
 - Check that the version of node-sass you're trying to install supports your version of Node by looking at the release page for that version https://github.com/sass/node-sass/releases
 - Read the common workarounds in the [TROUBLESHOOTING.md](https://github.com/sass/node-sass/blob/master/TROUBLESHOOTING.md)
-- [Search for duplicate or closed issues](https://github.com/sass/node-sass/issues?utf8=%E2%9C%93&q=is%3Aissue)
-- [Validate](http://sassmeister.com/) that it runs with both Ruby Sass and LibSass
-- Prepare a [reduced test case](https://css-tricks.com/reduced-test-cases/) for any bugs
 - Read the [contributing guidelines](https://github.com/sass/node-sass/blob/master/.github/CONTRIBUTING.md)
-
-When encountering a syntax, or compilation issue:
-
-- [Open an issue on `LibSass`](https://github.com/sass/LibSass/issues/new). You
-may link it back here, but any change will be required there, not here
 
 **When reporting an bug, YOU MUST PROVIDE THIS INFORMATION 
 or your issue will be closed without discussion**

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,5 @@
 <!--
 
-**Do not ask to but Request package, it breaks old Node compatiblity. It is used for downloading the binaries.**
-
 Before opening an issue:
 - Check that the version of node-sass you're trying to install supports your version of Node by looking at the release page for that version https://github.com/sass/node-sass/releases
 - Read the common workarounds in the [TROUBLESHOOTING.md](https://github.com/sass/node-sass/blob/master/TROUBLESHOOTING.md)

--- a/.github/ISSUE_TEMPLATE/Compile_results_are_incorrect.md
+++ b/.github/ISSUE_TEMPLATE/Compile_results_are_incorrect.md
@@ -1,0 +1,10 @@
+<!--
+When encountering a syntax, or compilation issue:
+
+- Please note that we cannot backport fixes to old versions, so ensure that you are running the latest release https://github.com/sass/node-sass/releases
+- Search for duplicate or closed issues https://github.com/sass/node-sass/issues?utf8=%E2%9C%93&q=is%3Aissue
+- Validate with http://sassmeister.com/ that the code works with Ruby Sass, then open an issue on `LibSass` https://github.com/sass/LibSass/issues/new
+
+Sorry you didn't have the experience you expected.
+
+-->

--- a/.github/ISSUE_TEMPLATE/Feature_Request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.md
@@ -1,0 +1,11 @@
+<!--
+
+Before you request a feature, please realize this project is a wrapper for
+LibSass so we can't add any language features here. If you want to add a feature
+to the Sass language, please open an issue on https://github.com/sass/sass/issues/new
+
+If you want a CLI feature, please make sure that it is supported by https://github.com/sass/sass
+
+Thanks for making node-sass better!
+
+-->

--- a/.github/ISSUE_TEMPLATE/Installation_Problem.md
+++ b/.github/ISSUE_TEMPLATE/Installation_Problem.md
@@ -1,11 +1,12 @@
 <!--
 
 Before opening an issue:
-- Check that the version of node-sass you're trying to install supports your version of Node by looking at the release page for that version https://github.com/sass/node-sass/releases
-- Read the common workarounds in the [TROUBLESHOOTING.md](https://github.com/sass/node-sass/blob/master/TROUBLESHOOTING.md)
-- Read the [contributing guidelines](https://github.com/sass/node-sass/blob/master/.github/CONTRIBUTING.md)
 
-**When reporting an bug, YOU MUST PROVIDE THIS INFORMATION 
+- Check that the version of node-sass you're trying to install supports your version of Node by looking at the release page for that version https://github.com/sass/node-sass/releases
+- If you're running the latest verions of Node, you'll likely need the latest node-sass, we don't backport support to old versions of node-sass
+- Read the common workarounds in https://github.com/sass/node-sass/blob/master/TROUBLESHOOTING.md
+
+**When reporting an bug, YOU MUST PROVIDE THE FOLLOWING INFORMATION
 or your issue will be closed without discussion**
 -->
 

--- a/.github/ISSUE_TEMPLATE/Request_Security.md
+++ b/.github/ISSUE_TEMPLATE/Request_Security.md
@@ -1,0 +1,3 @@
+# Please do not open an issue
+
+See https://github.com/sass/node-sass/issues/2355 for the reason we can't upgrade the Request version that your security scanner is flagging.


### PR DESCRIPTION
Related to https://github.com/sass/node-sass/issues/2365 but we'll need to actually setup the templates themselves before that one can be closed