### PR TITLE
Upgrade vulnerable dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "eslint": "^3.4.0",
     "fs-extra": "^0.30.0",
     "istanbul": "^0.4.2",
-    "mocha": "^3.1.2",
+    "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.2.0",
     "object-merge": "^2.5.1",
     "read-yaml": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "true-case-path": "^1.0.2"
   },
   "devDependencies": {
-    "coveralls": "^2.11.8",
+    "coveralls": "^3.0.1",
     "eslint": "^3.4.0",
     "fs-extra": "^0.30.0",
     "istanbul": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "nan": "^2.10.0",
     "node-gyp": "^3.3.1",
     "npmlog": "^4.0.0",
-    "request": "~2.79.0",
+    "request": "^2.87.0",
     "sass-graph": "^2.2.4",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^1.0.2"


### PR DESCRIPTION
Upgrading vulnerable dependencies per npm audit suggestions. 

https://docs.npmjs.com/getting-started/running-a-security-audit

This is my first contribution for this project and would like any feedback concerns with this change since there are many here that have deep knowledge of this codebase. I compared the test runs, builds, coverage, linting before and after the upgrades. The potential breaking changes are the dev-dependencies coveralls & mocha. 

Most are related to package hoek used in requests and coveralls: https://nodesecurity.io/advisories/566

Running ```npm audit```

```
=== npm audit security report ===

found 17 vulnerabilities (1 low, 15 moderate, 1 critical) in 1206 scanned packages
  run `npm audit fix` to fix 10 of them.
  7 vulnerabilities require semver-major dependency updates.
```

Auto fixed 10 packages
```
npm audit fix
+ request@2.87.0
added 15 packages from 18 contributors, removed 5 packages and updated 9 packages in 2.776s
fixed 10 of 17 vulnerabilities in 1206 scanned packages
  2 package updates for 7 vulns involved breaking changes
  (use `npm audit fix --force` to install breaking changes; or do it by hand)
```

Potential breaking changes in 2 packages
```
npm audit

=== npm audit security report ===

npm install --save-dev coveralls@3.0.1  to resolve 5 vulnerabilities
SEMVER WARNING: Recommended action is a potentially breaking change

npm install --save-dev mocha@5.2.0  to resolve 2 vulnerabilities
SEMVER WARNING: Recommended action is a potentially breaking change

critical within mocha https://nodesecurity.io/advisories/146
```

After manual upgrades of coveralls and mocha
```
=== npm audit security report ===

found 0 vulnerabilities
 in 1142 scanned packages
```

Tests (same before and after)
```
6101 passing (22s)
580 pending
```
