### PR TITLE
Update request to avoid moderate vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "nan": "^2.10.0",
     "node-gyp": "^3.3.1",
     "npmlog": "^4.0.0",
-    "request": "~2.79.0",
+    "request": "^2.81.0",
     "sass-graph": "^2.2.4",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^1.0.2"


### PR DESCRIPTION
Currently included version of request includes deprecated version of tunnel-agent with known moderate vulnerability. Add caret and bump version to remedy.

<!--

**Do not bump the Request package, it breaks old Node compatiblity. It is used for downloading the binaries.**

Thanks for contibuting otherwise!
-->
