### PR TITLE
dropping node-gyp as direct dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ before_install:
   - g++ --version
 
 install:
+  - npm install -g node-gyp
   - npm install
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,6 +75,7 @@
     - ps: Install-Product node $env:nodejs_version $env:platform
     - node --version
     - npm --version
+    - npm install -g node-gyp
     - npm install
 
   test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,7 +75,6 @@
     - ps: Install-Product node $env:nodejs_version $env:platform
     - node --version
     - npm --version
-    - npm install -g node-gyp
     - npm install
 
   test: off
@@ -160,6 +159,7 @@
     - ps: Install-Product node $env:nodejs_version $env:platform
     - node --version
     - npm --version
+    - npm install -g node-gyp
     - npm install
 
   test_script:

--- a/package.json
+++ b/package.json
@@ -66,9 +66,8 @@
     "meow": "^3.7.0",
     "mkdirp": "^0.5.1",
     "nan": "^2.10.0",
-    "node-gyp": "^3.3.1",
     "npmlog": "^4.0.0",
-    "request": "~2.79.0",
+    "request": "^2.86.0",
     "sass-graph": "^2.2.4",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "mkdirp": "^0.5.1",
     "nan": "^2.10.0",
     "npmlog": "^4.0.0",
-    "request": "^2.86.0",
+    "request": "~2.79.0",
     "sass-graph": "^2.2.4",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^1.0.2"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -19,9 +19,9 @@ function afterBuild(options) {
   var install = sass.getBinaryPath();
   var target = path.join(__dirname, '..', 'build',
     options.debug ? 'Debug' :
-        process.config.target_defaults
-            ?  process.config.target_defaults.default_configuration
-            : 'Release',
+      process.config.target_defaults
+        ?  process.config.target_defaults.default_configuration
+        : 'Release',
     'binding.node');
 
   mkdir(path.dirname(install), function(err) {
@@ -57,7 +57,6 @@ function afterBuild(options) {
 
 function build(options) {
   // get global npm bin directory
-  var globalBinPath = spawn.sync('npm', ['bin', '-g'], { stdout: 'inherit' }).stdout.toString().trim();
   var nodeGypExec = getNodeGyp();
   
   if (!nodeGypExec) {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -161,20 +161,29 @@ function testBinary(options) {
  */
 
 function getNodeGyp(){
-  var globalBinPath = spawn.sync('npm', ['bin', '-g'], { stdout: 'inherit' }).stdout.toString().trim();
   var localBinPath = spawn.sync('npm', ['bin'], { stdout: 'inherit' }).stdout.toString().trim();
+  var globalBinPath = spawn.sync('npm', ['bin', '-g'], { stdout: 'inherit' }).stdout.toString().trim();
+  var npmBinPath = spawn.sync('npm', ['bin', '-g'], { stdout: 'inherit' }).stdout.toString().trim();
+
   var nodeGypExec = null;
-  
   try{
-    nodeGypExec = require.resolve(globalBinPath+'/node-gyp');
+    nodeGypExec = require.resolve(localBinPath+'/node-gyp');
   }catch(errorGlobal){
-    console.error('unable to resolve node-gyp globally!`');
+    console.error('unable to resolve node-gyp locally!`');
+  }
+  
+  if(!nodeGypExec){
+    try{
+      nodeGypExec = require.resolve(globalBinPath+'/node-gyp');
+    }catch(errorGlobal){
+      console.error('unable to resolve node-gyp globally!`');
+    }
   }
   if(!nodeGypExec){
     try{
-      nodeGypExec = require.resolve(localBinPath+'/node-gyp');
+      nodeGypExec = require.resolve(npmBinPath+'/../lib/node_modules/node-gyp/bin/node-gyp.js');
     }catch(errorGlobal){
-      console.error('unable to resolve node-gyp locally!`');
+      console.error('unable to resolve node-gyp in npm!`');
     }
   }
 


### PR DESCRIPTION
referencing 
https://github.com/nodejs/node-gyp/issues/1439#issuecomment-397255452
and 
https://github.com/sass/node-sass/issues/2355#issuecomment-397395712

node-gyp should be used as provided with the node installations.