### PR TITLE
Bump request@2.87.0 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,0 @@
-<!--
-
-**Do not bump the Request package, it breaks old Node compatiblity. It is used for downloading the binaries.**
-
-Follow https://github.com/sass/node-sass/issues/2355 for updates on when that will be resolved.
-
-Thanks for contibuting otherwise!
--->

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,12 @@ jobs:
     - stage: platform-test
       node_js: "lts/argon"
       os: osx
+    - stage: platform-test
+      node_js: "0.12"
+      os: linux
+    - stage: platform-test
+      node_js: "0.10"
+      os: linux
 
 addons:
   apt:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -136,6 +136,12 @@
   environment:
     SKIP_SASS_BINARY_DOWNLOAD_FOR_CI: true
     matrix:
+      - nodejs_version: 0.10
+        GYP_MSVS_VERSION: 2013
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      - nodejs_version: 0.12
+        GYP_MSVS_VERSION: 2013
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       - nodejs_version: 4
         GYP_MSVS_VERSION: 2013
         APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013

--- a/package.json
+++ b/package.json
@@ -68,13 +68,13 @@
     "nan": "^2.10.0",
     "node-gyp": "^3.3.1",
     "npmlog": "^4.0.0",
-    "request": "~2.79.0",
+    "request": "2.87.0",
     "sass-graph": "^2.2.4",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^1.0.2"
   },
   "devDependencies": {
-    "coveralls": "^2.11.8",
+    "coveralls": "^3.0.2",
     "eslint": "^3.4.0",
     "fs-extra": "^0.30.0",
     "istanbul": "^0.4.2",


### PR DESCRIPTION
request@2.87.0 removed the dependency on `hoek` (request/request#2943)
which restores support for Node < 4. This means we bump to the latest
`request` to resolve the `npm audit` warnings.

Additionally I had to bump `coveralls@^3` to resolve a dependency
mismatch with `request`.

I've added back the CI checks for old Node for the v4 branch.

Fixes #2355