### PR TITLE
chore: Remove Travis Gitter hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,9 +97,3 @@ cache:
     - $HOME/.node-gyp
     - $HOME/.npm
     - node_modules
-
-notifications:
-  webhooks:
-    urls:
-      - https://webhooks.gitter.im/e/8dddd234a441d0d07664
-    on_success: change


### PR DESCRIPTION
Not sure if anyone is still using the channel, but the CI messages probably aren't useful there anyway