### PR TITLE
fix(cli): option --quiet now properly suppresses all stdout except in case of error

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -157,7 +157,7 @@ function getEmitter() {
 
   if (!options.quiet) {
     emitter.on('warn', function(data) {
-        console.warn(data);
+      console.warn(data);
     });
 
     emitter.on('info', function(data) {

--- a/bin/node-sass
+++ b/bin/node-sass
@@ -155,19 +155,17 @@ function getEmitter() {
     }
   });
 
-  emitter.on('warn', function(data) {
-    if (!options.quiet) {
-      console.warn(data);
-    }
-  });
+  if (!options.quiet) {
+    emitter.on('warn', function(data) {
+        console.warn(data);
+    });
 
-  emitter.on('info', function(data) {
-    if (!options.quiet) {
+    emitter.on('info', function(data) {
       console.info(data);
-    }
-  });
+    });
 
-  emitter.on('log', stdout.write.bind(stdout));
+    emitter.on('log', stdout.write.bind(stdout));
+  }
 
   return emitter;
 }

--- a/test/cli.js
+++ b/test/cli.js
@@ -44,17 +44,15 @@ describe('cli', function() {
     });
 
     it('should compile with the --quiet option', function(done) {
-      var src = fs.createReadStream(fixture('simple/index.scss'));
-      var expected = read(fixture('simple/expected.css'), 'utf8').trim();
-      var bin = spawn(cli, ['--quiet']);
+      var src = fixture('simple/index.scss');
+      var dest = fixture('simple/index.css');
+      var bin = spawn(cli, [src, ['--quiet'], '--output', path.dirname(dest)]);
 
-      bin.stdout.setEncoding('utf8');
-      bin.stdout.once('data', function(data) {
-        assert.equal(data.trim(), expected.replace(/\r\n/g, '\n'));
+      bin.once('close', function() {
+        assert(fs.existsSync(dest));
+        fs.unlinkSync(dest);
         done();
       });
-
-      src.pipe(bin.stdin);
     });
 
     it('should compile with the --output-style option', function(done) {


### PR DESCRIPTION
The  `--quiet` option is supposed to "Suppress log output except on error"; however, it currently is only suppressing `warn` and `info` level and lets `log` level through to stdout.

An example of this is if you ran `node-sass --quiet /some/file.scss` you would expect this to only emit on error for use in say a CI stage.  However, this currently will output the entire resulting .css to stdout.

  This PR changes this to properly suppress log output except on error.