### PR TITLE
when watching entire directory, don't rebuild files outside said directory

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -246,7 +246,9 @@ function watch(options, emitter) {
     });
 
     files.changed.forEach(function(file) {
-      if (path.basename(file)[0] !== '_') {
+      var srcDir = options.directory && path.join(process.cwd(), options.directory);
+      var isInclude = srcDir && file.indexOf(srcDir) === -1;
+      if (path.basename(file)[0] !== '_' && !isInclude) {
         renderFile(file, options, emitter);
       }
     });

--- a/test/cli.js
+++ b/test/cli.js
@@ -387,6 +387,31 @@ describe('cli', function() {
         }, 200);
       }, 500);
     });
+
+    it.skip('should not compile changed files outside watched directory', function(done) {
+      var rootDir = fixture('watching-dir-03/');
+      var destDir = fixture('watching-dir-03/dest');
+      var srcDir = fixture('watching-dir-03/src');
+      var outsideFile = path.join(rootDir, 'outside.scss');
+
+      fs.writeFileSync(outsideFile, '');
+
+      var bin = spawn(cli, [
+        '--output', destDir,
+        '--watch', srcDir
+      ]);
+
+      setTimeout(function () {
+        fs.appendFileSync(outsideFile, 'body{background:white}\n');
+        setTimeout(function () {
+          bin.kill();
+          var files = fs.readdirSync(rootDir);
+          assert.deepEqual(files, [ 'dest', 'outside.scss', 'src' ]);
+          rimraf(destDir, done);
+        }, 200);
+      }, 500);
+    });
+
   });
 
   describe('node-sass in.scss --output out.css', function() {

--- a/test/fixtures/watching-dir-03/outside.scss
+++ b/test/fixtures/watching-dir-03/outside.scss
@@ -1,0 +1,1 @@
+body{background:white}

--- a/test/fixtures/watching-dir-03/src/index.scss
+++ b/test/fixtures/watching-dir-03/src/index.scss
@@ -1,0 +1,1 @@
+@import "outside";


### PR DESCRIPTION
#2491 - small fix to the CLI so that non-underscored files outside the watched directory (but imported as part of the tree) are not built.

@xzyfer I've written a test for this with a fixture but `skipped` it as it looks like you're skipping most of the async tests? Let me know if you want me to add that back in to the list.

