### PR TITLE
Upgrade request package to v.2.88

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "nan": "^2.10.0",
     "node-gyp": "^3.8.0",
     "npmlog": "^4.0.0",
-    "request": "2.87.0",
+    "request": "^2.88.0",
     "sass-graph": "^2.2.4",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^1.0.2"


### PR DESCRIPTION
The package `extend 3.0.1`, which is a dependency of `request 2.87` has a vulnerability :
https://hackerone.com/reports/381185

Upgrade `request` to v.2.88 will install `extend` v.3.0.2, the fixed version.

Fix #2496

