### PR TITLE
Adding need for --output when wanting to create a source map file

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ The `input` can be either a single `.scss` or `.sass`, or a directory. If the in
 
 Also, note `--importer` takes the (absolute or relative to pwd) path to a js file, which needs to have a default `module.exports` set to the importer function. See our test [fixtures](https://github.com/sass/node-sass/tree/974f93e76ddd08ea850e3e663cfe64bb6a059dd3/test/fixtures/extras) for example.
 
-The `--source-map` option accepts a boolean value, in which case it replaces destination extension with `.css.map`. It also accepts path to `.map` file and even path to the desired directory.
+The `--source-map` option accepts a boolean value, in which case it replaces destination extension with `.css.map`. It also accepts path to `.map` file and even path to the desired directory. When specifying a path, the `--output` must be supplied.
 When compiling a directory `--source-map` can either be a boolean value or a directory.
 
 ## Binary configuration parameters


### PR DESCRIPTION
This is a puzzling issue and I only solved it because I found this in a bug report.