### PR TITLE
Suppress -std=c++0x option for zOS

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -80,7 +80,7 @@
             },
           },
         }],
-        ['OS!="win"', {
+        ['OS!="win" and OS!="zos"', {
           'cflags_cc+': [
             '-std=c++0x'
           ]

--- a/src/libsass.gyp
+++ b/src/libsass.gyp
@@ -103,7 +103,7 @@
              }]
           ]
         }],
-        ['OS!="win"', {
+        ['OS!="win" and OS!="zos"', {
           'cflags_cc+': [
             '-std=c++0x'
           ]


### PR DESCRIPTION
The njsc/c++ compiler used for Node.js on z/OS has C++11 support by
default.  The -std=c++0x option currently triggers a FSUM3210 error,
hence, updating gyp files to suppress use of this option on the
platform (similar to what's currently done for Windows).

Signed-off-by: Joran Siu <joransiu@ca.ibm.com>

