### PR TITLE
Remove @adamyeats from maintainers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,7 +609,6 @@ This module is brought to you and maintained by the following people:
 * Keith Cirkel ([Github](https://github.com/keithamus) / [Twitter](https://twitter.com/Keithamus))
 * Laurent Goderre ([Github](https://github.com/laurentgoderre) / [Twitter](https://twitter.com/laurentgoderre))
 * Nick Schonning ([Github](https://github.com/nschonni) / [Twitter](https://twitter.com/nschonni))
-* Adam Yeats ([Github](https://github.com/adamyeats) / [Twitter](https://twitter.com/adamyeats))
 * Adeel Mujahid ([Github](https://github.com/am11) / [Twitter](https://twitter.com/adeelbm))
 
 ## Contributors


### PR DESCRIPTION
Hi all! 👋 As I don't have access to my old GitHub account anymore (I lost the 2FA backup code to the `adamyeats` account years ago and can't log in), and no longer have access to the `sass` organisation, I am removing myself from the maintainers list.

Best wishes to all and good luck! 👍 

