### PR TITLE
Added an environment variable to suppress DEPRECATION WARNS - Issue #2334

### DIFF
--- a/src/libsass/src/error_handling.cpp
+++ b/src/libsass/src/error_handling.cpp
@@ -181,42 +181,48 @@ namespace Sass {
 
   void deprecated_function(std::string msg, ParserState pstate)
   {
-    std::string cwd(Sass::File::get_cwd());
-    std::string abs_path(Sass::File::rel2abs(pstate.path, cwd, cwd));
-    std::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
-    std::string output_path(Sass::File::path_for_console(rel_path, abs_path, pstate.path));
+    if (!!process.env.NODE_SASS_NO_DEPRECATION && process.env.NODE_SASS_NO_DEPRECATION !== '0') {
+      std::string cwd(Sass::File::get_cwd());
+      std::string abs_path(Sass::File::rel2abs(pstate.path, cwd, cwd));
+      std::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
+      std::string output_path(Sass::File::path_for_console(rel_path, abs_path, pstate.path));
 
-    std::cerr << "DEPRECATION WARNING: " << msg << std::endl;
-    std::cerr << "will be an error in future versions of Sass." << std::endl;
-    std::cerr << "        on line " << pstate.line+1 << " of " << output_path << std::endl;
+      std::cerr << "DEPRECATION WARNING: " << msg << std::endl;
+      std::cerr << "will be an error in future versions of Sass." << std::endl;
+      std::cerr << "        on line " << pstate.line+1 << " of " << output_path << std::endl;
+    }
   }
 
   void deprecated(std::string msg, std::string msg2, bool with_column, ParserState pstate)
   {
-    std::string cwd(Sass::File::get_cwd());
-    std::string abs_path(Sass::File::rel2abs(pstate.path, cwd, cwd));
-    std::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
-    std::string output_path(Sass::File::path_for_console(rel_path, pstate.path, pstate.path));
+    if (!!process.env.NODE_SASS_NO_DEPRECATION && process.env.NODE_SASS_NO_DEPRECATION !== '0') {
+      std::string cwd(Sass::File::get_cwd());
+      std::string abs_path(Sass::File::rel2abs(pstate.path, cwd, cwd));
+      std::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
+      std::string output_path(Sass::File::path_for_console(rel_path, pstate.path, pstate.path));
 
-    std::cerr << "DEPRECATION WARNING on line " << pstate.line + 1;
-    if (with_column) std::cerr << ", column " << pstate.column + pstate.offset.column + 1;
-    if (output_path.length()) std::cerr << " of " << output_path;
-    std::cerr << ":" << std::endl;
-    std::cerr << msg << std::endl;
-    if (msg2.length()) std::cerr << msg2 << std::endl;
-    std::cerr << std::endl;
+      std::cerr << "DEPRECATION WARNING on line " << pstate.line + 1;
+      if (with_column) std::cerr << ", column " << pstate.column + pstate.offset.column + 1;
+      if (output_path.length()) std::cerr << " of " << output_path;
+      std::cerr << ":" << std::endl;
+      std::cerr << msg << std::endl;
+      if (msg2.length()) std::cerr << msg2 << std::endl;
+      std::cerr << std::endl;
+    }
   }
 
   void deprecated_bind(std::string msg, ParserState pstate)
   {
-    std::string cwd(Sass::File::get_cwd());
-    std::string abs_path(Sass::File::rel2abs(pstate.path, cwd, cwd));
-    std::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
-    std::string output_path(Sass::File::path_for_console(rel_path, abs_path, pstate.path));
+    if (!!process.env.NODE_SASS_NO_DEPRECATION && process.env.NODE_SASS_NO_DEPRECATION !== '0') {
+      std::string cwd(Sass::File::get_cwd());
+      std::string abs_path(Sass::File::rel2abs(pstate.path, cwd, cwd));
+      std::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
+      std::string output_path(Sass::File::path_for_console(rel_path, abs_path, pstate.path));
 
-    std::cerr << "WARNING: " << msg << std::endl;
-    std::cerr << "        on line " << pstate.line+1 << " of " << output_path << std::endl;
-    std::cerr << "This will be an error in future versions of Sass." << std::endl;
+      std::cerr << "DEPRECATION WARNING: " << msg << std::endl;
+      std::cerr << "        on line " << pstate.line+1 << " of " << output_path << std::endl;
+      std::cerr << "This will be an error in future versions of Sass." << std::endl;
+    }
   }
 
   // should be replaced with error with backtraces

--- a/src/libsass/src/functions.cpp
+++ b/src/libsass/src/functions.cpp
@@ -1850,10 +1850,12 @@ namespace Sass {
 
       if (ss) {
         name = Util::normalize_underscores(unquote(ss->value()));
-        std::cerr << "DEPRECATION WARNING: ";
-        std::cerr << "Passing a string to call() is deprecated and will be illegal" << std::endl;
-        std::cerr << "in Sass 4.0. Use call(get-function(" + quote(name) + ")) instead." << std::endl;
-        std::cerr << std::endl;
+        if (!!process.env.NODE_SASS_NO_DEPRECATION && process.env.NODE_SASS_NO_DEPRECATION !== '0') {
+          std::cerr << "DEPRECATION WARNING: ";
+          std::cerr << "Passing a string to call() is deprecated and will be illegal" << std::endl;
+          std::cerr << "in Sass 4.0. Use call(get-function(" + quote(name) + ")) instead." << std::endl;
+          std::cerr << std::endl;
+        }
       } else if (ff) {
         name = ff->name();
       }


### PR DESCRIPTION
Added env variable called `NODE_SASS_NO_DEPRECATION`, so everyone can be able to disable deprecation warnings.

Warnings will stop being shown by setting the variable `NODE_SASS_NO_DEPRECATION` to `0`

This is related to issue #2334, you may modify variable name and configuration value as you wish, the idea of this PR is just to give everyone _some hope_ of a possible solution.