### PR TITLE
fix(cli): option --quiet suppresses output expect for error

### DIFF
--- a/bin/node-sass
+++ b/bin/node-sass
@@ -155,19 +155,17 @@ function getEmitter() {
     }
   });
 
-  emitter.on('warn', function(data) {
-    if (!options.quiet) {
+  if (!options.quiet) {
+    emitter.on('warn', function(data) {
       console.warn(data);
-    }
-  });
+    });
 
-  emitter.on('info', function(data) {
-    if (!options.quiet) {
+    emitter.on('info', function(data) {
       console.info(data);
-    }
-  });
+    });
 
-  emitter.on('log', stdout.write.bind(stdout));
+    emitter.on('log', stdout.write.bind(stdout));
+  }
 
   return emitter;
 }

--- a/test/cli.js
+++ b/test/cli.js
@@ -44,17 +44,15 @@ describe('cli', function() {
     });
 
     it('should compile with the --quiet option', function(done) {
-      var src = fs.createReadStream(fixture('simple/index.scss'));
-      var expected = read(fixture('simple/expected.css'), 'utf8').trim();
-      var bin = spawn(cli, ['--quiet']);
+      var src = fixture('simple/index.scss');
+      var dest = fixture('simple/index.css');
+      var bin = spawn(cli, [src, ['--quiet'], '--output', path.dirname(dest)]);
 
-      bin.stdout.setEncoding('utf8');
-      bin.stdout.once('data', function(data) {
-        assert.equal(data.trim(), expected.replace(/\r\n/g, '\n'));
+      bin.once('close', function() {
+        assert(fs.existsSync(dest));
+        fs.unlinkSync(dest);
         done();
       });
-
-      src.pipe(bin.stdin);
     });
 
     it('should compile with the --output-style option', function(done) {


### PR DESCRIPTION
### Background

The `--quiet` option is supposed to "Suppress log output except on error" per the documentation:
https://github.com/sass/node-sass/blame/master/README.md#L547
however, it currently is only suppressing `warn` and `info` level and lets `log` level through.

If you ran `node-sass --quiet /some/file.scss` you would expect this to only emit on error, however, this currently will output the entire resulting .css to stdout.  An example of when you would not want the resulting css but would only want an error if one occurred is if you were using the command as a CI step to verify that the scss was valid.

### Solution
This PR makes the `--quiet` option properly suppress log output except on error.

Closes #2599