### PR TITLE
Remove sudo settings from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 compiler: gcc
-sudo: false
 
 env:
   global:


### PR DESCRIPTION
'sudo' seems to be unavailable.
Remove sudo settings from .travis.yml

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

<!--
Please do not open PRs to bump node-gyp to 4.0, 
please follow https://github.com/sass/node-sass/issues/2625 instead
-->
