### PR TITLE
Bump sass-graph@^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "node-gyp": "^3.8.0",
     "npmlog": "^4.0.0",
     "request": "^2.88.0",
-    "sass-graph": "^2.2.4",
+    "sass-graph": "^3.0.0",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^1.0.2"
   },


### PR DESCRIPTION
Sass-graph is pulling in an old lodash version that has security alerts out for it. This bumps sass-graph to 3.0.0. [The only breaking change is that it doesn't read .css files by default and it requires Node >= 6.](https://github.com/xzyfer/sass-graph/releases/tag/v3.0.0)

Closes #2614 