### PR TITLE
Remove test from published package. Address #2709

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "lib",
     "scripts",
     "src",
-    "test",
     "vendor"
   ],
   "keywords": [


### PR DESCRIPTION
#2709 content:

> https://github.com/sass/node-sass/blob/master/package.json#L44
> <img src="https://user-images.githubusercontent.com/516342/61464219-d0231400-a96d-11e9-9abe-e0fa494946e3.png" width="200">
>
> It appears that this directory includes only test files. I think it should be excluded from NPM package.
> This way test frameworks will also not try to parse it when running without excluding node_modules explicitly (which fails because of missing devDependencies, of course).