### PR TITLE
Fix #2394: sourceMap option should have consistent behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,9 +310,11 @@ Used to determine how many digits after the decimal will be allowed. For instanc
 * Type: `Boolean | String | undefined`
 * Default: `undefined`
 
-**Special:** Setting the `sourceMap` option requires also setting the `outFile` option
+Enables source map generation during `render` and `renderSync`.
 
-Enables the outputting of a source map during `render` and `renderSync`. When `sourceMap === true`, the value of `outFile` is used as the target output location for the source map. When `typeof sourceMap === "string"`, the value of `sourceMap` will be used as the writing location for the file.
+When `sourceMap === true`, the value of `outFile` is used as the target output location for the source map with the suffix `.map` appended. If no `outFile` is set, `sourceMap` parameter is ignored.
+
+When `typeof sourceMap === "string"`, the value of `sourceMap` will be used as the writing location for the file.
 
 ### sourceMapContents
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -300,9 +300,11 @@ module.exports.render = function(opts, cb) {
     var stats = endStats(result.stats);
     var payload = {
       css: result.css,
-      map: result.map,
       stats: stats
     };
+    if (result.map) {
+      payload.map = result.map;
+    }
 
     if (cb) {
       options.context.callback.call(options.context, null, payload);

--- a/test/api.js
+++ b/test/api.js
@@ -63,6 +63,26 @@ describe('api', function() {
       });
     });
 
+    it('should not generate source map when not requested', function(done) {
+      sass.render({
+        file: fixture('simple/index.scss'),
+        sourceMap: false
+      }, function(error, result) {
+        assert.strictEqual(result.hasOwnProperty('map'), false, 'result has a map property');
+        done();
+      });
+    });
+
+    it('should not generate source map without outFile and no explicit path given', function(done) {
+      sass.render({
+        file: fixture('simple/index.scss'),
+        sourceMap: true
+      }, function(error, result) {
+        assert.strictEqual(result.hasOwnProperty('map'), false, 'result has a map property');
+        done();
+      });
+    });
+
     it('should compile generate map with sourceMapRoot pass-through option', function(done) {
       sass.render({
         file: fixture('simple/index.scss'),
@@ -1345,6 +1365,26 @@ describe('api', function() {
       });
 
       assert.equal(JSON.parse(result.map).file, '../../index-test.css');
+      done();
+    });
+
+    it('should not generate source map when not requested', function(done) {
+      var result =  sass.renderSync({
+        file: fixture('simple/index.scss'),
+        sourceMap: false
+      });
+
+      assert.strictEqual(result.hasOwnProperty('map'), false, 'result has a map property');
+      done();
+    });
+
+    it('should not generate source map without outFile and no explicit path given', function(done) {
+      var result =  sass.renderSync({
+        file: fixture('simple/index.scss'),
+        sourceMap: true
+      });
+
+      assert.strictEqual(result.hasOwnProperty('map'), false, 'result has a map property');
       done();
     });
 


### PR DESCRIPTION
render() and renderSync() should return "map" property in the results
only if source map has been enabled.