### PR TITLE
Fix #2621: Report libsass version 3.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-sass",
   "version": "4.13.0",
-  "libsass": "3.5.4",
+  "libsass": "3.5.5",
   "description": "Wrapper around libsass",
   "license": "MIT",
   "bugs": "https://github.com/sass/node-sass/issues",


### PR DESCRIPTION
@xzyfer can we push 4.13.0 to include this? unfortunately the binaries have to be re-built

Fixes #2621