### PR TITLE
Test against arm64 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ jobs:
     - stage: test
       node_js: "12"
       os: linux
+      arch: amd64
+      before_script: npm run lint || exit 1;
+      after_success: npm run-script coverage;
+    - stage: test
+      node_js: "12"
+      os: linux
+      arch: arm64
       before_script: npm run lint || exit 1;
       after_success: npm run-script coverage;
     - stage: platform-test
@@ -15,12 +22,22 @@ jobs:
     - stage: platform-test
       node_js: "10"
       os: linux
+      arch: amd64
+    - stage: platform-test
+      node_js: "10"
+      os: linux
+      arch: arm64
     - stage: platform-test
       node_js: "10"
       os: osx
     - stage: platform-test
       node_js: "13"
       os: linux
+      arch: amd64
+    - stage: platform-test
+      node_js: "13"
+      os: linux
+      arch: arm64
     - stage: platform-test
       node_js: "13"
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,37 +10,35 @@ jobs:
       arch: amd64
       before_script: npm run lint || exit 1;
       after_success: npm run-script coverage;
-    - stage: test
-      node_js: "12"
-      os: linux
-      arch: arm64
-      before_script: npm run lint || exit 1;
-      after_success: npm run-script coverage;
     - stage: platform-test
       node_js: "12"
       os: osx
+    - stage: platform-test
+      node_js: "12"
+      os: linux
+      arch: arm64
     - stage: platform-test
       node_js: "10"
       os: linux
       arch: amd64
     - stage: platform-test
       node_js: "10"
-      os: linux
-      arch: arm64
+      os: osx
     - stage: platform-test
       node_js: "10"
-      os: osx
+      os: linux
+      arch: arm64
     - stage: platform-test
       node_js: "13"
       os: linux
       arch: amd64
     - stage: platform-test
       node_js: "13"
-      os: linux
-      arch: arm64
+      os: osx
     - stage: platform-test
       node_js: "13"
-      os: osx
+      os: linux
+      arch: arm64
 
 addons:
   apt:

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -44,6 +44,11 @@ function getHumanArchitecture(arch) {
     case 'ia32': return '32-bit';
     case 'x86': return '32-bit';
     case 'x64': return '64-bit';
+    case 'armv7l': return '32-bit, ARM';
+    case 'armv7hf': return '32-bit, ARM';
+    case 'armv8': return '64-bit, ARM';
+    case 'aarch64': return '64-bit, ARM';
+    case 'arm64': return '64-bit, ARM';
     default: return false;
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "install": "node scripts/install.js",
     "postinstall": "node scripts/build.js",
     "lint": "node_modules/.bin/eslint bin/node-sass lib scripts test",
-    "test": "node_modules/.bin/mocha test/{*,**/**}.js",
+    "test": "node_modules/.bin/mocha test/{*,**/**}.js --timeout 5000ms",
     "build": "node scripts/build.js --force",
     "prepublish": "not-in-install && node scripts/prepublish.js || in-install"
   },


### PR DESCRIPTION
Follow-up to #2647, but instead of using a new CI service we use [Travis new support for multiple CPU architectures](https://docs.travis-ci.com/user/multi-cpu-architectures/)