### PR TITLE
chore: Add GitHub Actions for Alpine CI

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -1,0 +1,49 @@
+name: Build bindings for Alpine releases
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: node:${{ matrix.node }}-alpine${{ matrix.alpine }}
+      env:
+        SKIP_SASS_BINARY_DOWNLOAD_FOR_CI: true
+    strategy:
+      matrix:
+        node:
+          - 6
+          - 8.16.2
+          - 10
+          - 12
+          - 13
+          - 14
+        include:
+          - node: 6
+            alpine: ""
+          - node: 8.16.2
+            alpine: "3.9"
+          - node: 10
+            alpine: "3.9"
+          - node: 12
+            alpine: "3.9"
+          - node: 13
+            alpine: "3.10"
+          - node: 14
+            alpine: "3.10"
+    steps:
+      - name: Install Alpine build tools
+        run: apk add --no-cache python make git gcc g++
+
+      - uses: actions/checkout@v2
+
+      - name: Install packages
+        run: npm install --unsafe-perm
+
+      - name: Run tests
+        run: npm test
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ${{ matrix.node }}
+          path: vendor/


### PR DESCRIPTION
Adds some CI for the Alpine images to speed up releases.
If this works out, I might take a look at converting some of the others.
This also uploads the artifacts as a zip on successful builds. This could be modified to only run on tags later

Note: ran into an issue with the Node 8.17.0 alpine images. You can see an example log here https://gist.github.com/nschonni/491cd2ae724e1f24db3b76b37698ab1c
Main issues is probably around
```
2020-01-18T03:50:16.3975372Z npm ERR! Command failed: git clone --mirror -q https://github.com/sass/sass-spec.git /github/home/.npm/_cacache/tmp/git-clone-dbd532b1/.git
2020-01-18T03:50:16.3975793Z npm ERR! /github/home/.npm/_cacache/tmp/git-clone-dbd532b1/.git: Permission denied
```
where the git sass-spec is failing. Tried a bunch of troubleshooting, but just decided to pin to the previous version that was working.

PS: I don't think the CI will show up till this lands, but you can see the build here https://github.com/nschonni/node-sass/commit/c288e6067650d9ebd11980c6e320e8b409f422d8/checks?check_suite_id=407548884