### PR TITLE
chore: update chalk to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "style"
   ],
   "dependencies": {
-    "chalk": "^2.4.2",
+    "chalk": "^3.0.0",
     "chokidar": "^3.3.0",
     "cross-spawn": "^7.0.1",
     "get-stdin": "^7.0.0",


### PR DESCRIPTION
chalk v3 drops support for node < 8 and brings performance improvements