### PR TITLE
Bump node-gyp: match node lts built-in or greater

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "coverage": "node scripts/coverage.js",
     "install": "node scripts/install.js",
     "postinstall": "node scripts/build.js",
-    "lint": "node_modules/.bin/eslint bin/node-sass lib scripts test",
-    "test": "node_modules/.bin/mocha test/{*,**/**}.js",
+    "lint": "eslint bin/node-sass lib scripts test",
+    "test": "mocha test/{*,**/**}.js",
     "build": "node scripts/build.js --force",
-    "prepublish": "not-in-install && node scripts/prepublish.js || in-install"
+    "prepublishOnly": "node scripts/prepublish.js"
   },
   "files": [
     "bin",
@@ -59,12 +59,11 @@
     "gaze": "^1.0.0",
     "get-stdin": "^4.0.1",
     "glob": "^7.0.3",
-    "in-publish": "^2.0.0",
     "lodash": "^4.17.15",
     "meow": "^3.7.0",
     "mkdirp": "^0.5.1",
     "nan": "^2.13.2",
-    "node-gyp": "^3.8.0",
+    "node-gyp": "5 - 6",
     "npmlog": "^4.0.0",
     "request": "^2.88.0",
     "sass-graph": "^2.2.4",


### PR DESCRIPTION
node-gyp 5 supports node 6, so this will be semver major