### PR TITLE
package.json: fix npm scripts to work on all platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "coverage": "node scripts/coverage.js",
     "install": "node scripts/install.js",
     "postinstall": "node scripts/build.js",
-    "lint": "node_modules/.bin/eslint bin/node-sass lib scripts test",
-    "test": "node_modules/.bin/mocha test/{*,**/**}.js",
+    "lint": "eslint bin/node-sass lib scripts test",
+    "test": "mocha \"test/**/*.js\"",
     "build": "node scripts/build.js --force",
     "prepublish": "not-in-install && node scripts/prepublish.js || in-install"
   },


### PR DESCRIPTION
On Windows with the native cmd `node_modules/.bin/...` doesn't work.

Also, double quote the glob to make sure it works everywhere.

This will conflict with #2903, I will rebase as needed.