### PR TITLE
Bump sass-graph@2.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "node-gyp": "^3.8.0",
     "npmlog": "^4.0.0",
     "request": "^2.88.0",
-    "sass-graph": "^2.2.4",
+    "sass-graph": "2.2.5",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^1.0.2"
   },


### PR DESCRIPTION
This release fixes #2912 without breaking BC. See https://github.com/xzyfer/sass-graph/pull/110