### PR TITLE
chore(deps): update sass-graph to 3.0.5 to fix yargs-parser vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "node-gyp": "^3.8.0",
     "npmlog": "^4.0.0",
     "request": "^2.88.0",
-    "sass-graph": "2.2.5",
+    "sass-graph": "^3.0.5",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^1.0.2"
   },


### PR DESCRIPTION
Hello,

I wanted to update sass-graph to 3.0.5 the current version is 2.2.5.
This would update latest version of yargs-parser which will do away with the prototype vulnerability audit warnings.
As far as I can tell 2.2.6 was also released at the same time as 3.0.5 with the yargs updates. So maybe it's a better idea to update to just 2.2.6. But I still get a warning telling me to update to 3.0.5 when I tried it. 

If it doesn't hurt anything maybe its not a bad idea to update to the latest version. Thoughts?

 