### PR TITLE
fix memory leak based from 2018 patch on parse_ie_keyword_arg()

### DIFF
--- a/src/libsass/src/parser.cpp
+++ b/src/libsass/src/parser.cpp
@@ -1918,7 +1918,7 @@ namespace Sass {
 
   String_Obj Parser::parse_ie_keyword_arg()
   {
-    String_Schema_Ptr kwd_arg = SASS_MEMORY_NEW(String_Schema, pstate, 3);
+    String_Schema_Obj kwd_arg = SASS_MEMORY_NEW(String_Schema, pstate, 3);
     if (lex< variable >()) {
       kwd_arg->append(SASS_MEMORY_NEW(Variable, pstate, Util::normalize_underscores(lexed)));
     } else {


### PR DESCRIPTION
Affected versions of this package are vulnerable to Out-of-bounds Read via the function Sass::Prelexer::exactly() which could be leveraged by an attacker to disclose information or manipulated to read from unmapped memory causing a denial of service.