### PR TITLE
Python 3 support by bumping node-gyp to 6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "http://andrew.github.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">= 6"
   },
   "main": "lib/index.js",
   "nodeSassConfig": {
@@ -33,7 +33,7 @@
     "lint": "eslint bin/node-sass lib scripts test",
     "test": "mocha test/{*,**/**}.js",
     "build": "node scripts/build.js --force",
-    "prepublish": "not-in-install && node scripts/prepublish.js || in-install"
+    "prepublishOnly": "node scripts/prepublish.js"
   },
   "files": [
     "bin",
@@ -59,12 +59,11 @@
     "gaze": "^1.0.0",
     "get-stdin": "^4.0.1",
     "glob": "^7.0.3",
-    "in-publish": "^2.0.0",
     "lodash": "^4.17.15",
     "meow": "^3.7.0",
     "mkdirp": "^0.5.1",
     "nan": "^2.13.2",
-    "node-gyp": "^3.8.0",
+    "node-gyp": "^6.1.0",
     "npmlog": "^4.0.0",
     "request": "^2.88.0",
     "sass-graph": "2.2.5",


### PR DESCRIPTION
I know similar pull requests have been declined before because it breaks compatibility.

However the current v4 uses node-gyp@3.8.0 which does not support python 3. Python 2 is now [end of life](https://www.python.org/doc/sunset-python-2/) since 1 jan 2020 and major distrubutions are starting to drop it ([debian](https://lists.debian.org/debian-python/2019/07/msg00080.html), [fedora](https://fedoraproject.org/wiki/FinalizingFedoraSwitchtoPython3), [ubuntu](https://lists.ubuntu.com/archives/ubuntu-devel/2020-January/040869.html) etc). Python 3 support landed in [node-gyp@5.0.4](https://github.com/nodejs/node-gyp/pull/1893).

This is a problem because node-sass will no longer work for new installations where the precompiled binary cannot be used (enterprise firewalls anyone?). So for this user group (myself included) node-sass is effectively unusable right now.

I've already seen that v5 solves this issue but I don't see a timeline and it doesn't seem to be actively worked on. So my suggestion is to either declare this project dead and force users to use a replacement such as [dart-sass](https://github.com/sass/dart-sass) or merge this or a similar fix.

---

Since node-gyp@7.0.0 requires node 10 the minimal node version is bumped here as well. This makes sense since node 10 is the current oldest supported version.

*EDIT*: downgraded to 6.1.0 to support/require node 6 instead of 10.