### PR TITLE
chore: Bump cross-spawn to v7.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "async-foreach": "^0.1.3",
     "chalk": "^1.1.1",
-    "cross-spawn": "^3.0.0",
+    "cross-spawn": "^7.0.3",
     "gaze": "^1.0.0",
     "get-stdin": "^4.0.1",
     "glob": "^7.0.3",


### PR DESCRIPTION
Bumping Mocha uncovered a minor issue with the tests not cleanly exiting for the watch on Windows, but updated cross-spawn seems to resolve that again