### PR TITLE
chore: Prep README for v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Node <8 | <5.0                        | <57
 ![Windows x64](https://github.com/sass/node-sass/workflows/Build%20bindings%20for%20Windows%20releases/badge.svg)
 ![Linting](https://github.com/sass/node-sass/workflows/Lint%20JS/badge.svg)
 [![Windows x86](https://ci.appveyor.com/api/projects/status/22mjbk59kvd55m9y/branch/master?svg=true)](https://ci.appveyor.com/project/sass/node-sass/branch/master)
-[![npm version](https://badge.fury.io/js/node-sass.svg)](http://badge.fury.io/js/node-sass)
 [![Coverage Status](https://coveralls.io/repos/sass/node-sass/badge.svg?branch=master)](https://coveralls.io/r/sass/node-sass?branch=master)
 
 Node-sass is a library that provides binding for Node.js to [LibSass], the C version of the popular stylesheet preprocessor, Sass.

--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ Node <8 | <5.0                        | <57
   </tr>
 </table>
 
-[![Build Status](https://travis-ci.org/sass/node-sass.svg?branch=master&style=flat)](https://travis-ci.org/sass/node-sass)
-[![Build status](https://ci.appveyor.com/api/projects/status/22mjbk59kvd55m9y/branch/master?svg=true)](https://ci.appveyor.com/project/sass/node-sass/branch/master)
+![Alpine](https://github.com/sass/node-sass/workflows/Build%20bindings%20for%20Alpine%20releases/badge.svg)
+![Linux](https://github.com/sass/node-sass/workflows/Build%20bindings%20for%20Linux%20releases/badge.svg)
+![macOS](https://github.com/sass/node-sass/workflows/Build%20bindings%20for%20macOS%20releases/badge.svg)
+![Windows x64](https://github.com/sass/node-sass/workflows/Build%20bindings%20for%20Windows%20releases/badge.svg)
+![Linting](https://github.com/sass/node-sass/workflows/Lint%20JS/badge.svg)
+[![Windows x86](https://ci.appveyor.com/api/projects/status/22mjbk59kvd55m9y/branch/master?svg=true)](https://ci.appveyor.com/project/sass/node-sass/branch/master)
 [![npm version](https://badge.fury.io/js/node-sass.svg)](http://badge.fury.io/js/node-sass)
-[![Dependency Status](https://david-dm.org/sass/node-sass.svg?theme=shields.io)](https://david-dm.org/sass/node-sass)
-[![devDependency Status](https://david-dm.org/sass/node-sass/dev-status.svg?theme=shields.io)](https://david-dm.org/sass/node-sass#info=devDependencies)
 [![Coverage Status](https://coveralls.io/repos/sass/node-sass/badge.svg?branch=master)](https://coveralls.io/r/sass/node-sass?branch=master)
-[![Inline docs](http://inch-ci.org/github/sass/node-sass.svg?branch=master)](http://inch-ci.org/github/sass/node-sass)
 [![Join us in Slack](https://libsass-slack.herokuapp.com/badge.svg)](https://libsass-slack.herokuapp.com/)
 
 Node-sass is a library that provides binding for Node.js to [LibSass], the C version of the popular stylesheet preprocessor, Sass.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Node <8 | <5.0                        | <57
 [![Windows x86](https://ci.appveyor.com/api/projects/status/22mjbk59kvd55m9y/branch/master?svg=true)](https://ci.appveyor.com/project/sass/node-sass/branch/master)
 [![npm version](https://badge.fury.io/js/node-sass.svg)](http://badge.fury.io/js/node-sass)
 [![Coverage Status](https://coveralls.io/repos/sass/node-sass/badge.svg?branch=master)](https://coveralls.io/r/sass/node-sass?branch=master)
-[![Join us in Slack](https://libsass-slack.herokuapp.com/badge.svg)](https://libsass-slack.herokuapp.com/)
 
 Node-sass is a library that provides binding for Node.js to [LibSass], the C version of the popular stylesheet preprocessor, Sass.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,23 @@
 # node-sass
 
-#### Supported Node.js versions vary by release, please consult the [releases page](https://github.com/sass/node-sass/releases). Below is a quick guide for minimum support:
+## Node version support policy
 
-NodeJS  | Minimum node-sass version | Node Module
---------|--------------------------|------------
-Node 14 | 4.14+                    | 83
-Node 13 | 4.13+                    | 79
-Node 12 | 4.12+                    | 72
-Node 11 | 4.10+                    | 67
-Node 10 | 4.9+                     | 64
-Node 8  | 4.5.3+                   | 57
+1. Supported Node.js versions vary by release, please consult the [releases page](https://github.com/sass/node-sass/releases).
+1. Node versions that hit end of life <https://github.com/nodejs/Release>, will be dropped from support at each node-sass release (major, minor).
+1. We will stop building binaries for unsupported releases, testing for breakages in dependency compatibility, but we will not block installations for those that want to support themselves.
+1. New node release require minor internal changes along with support from CI providers (AppVeyor, GitHub Actions). We will open a single issue for interested parties to subscribe to, and close additional issues.
+
+Below is a quick guide for minimum and maximum support supported version of node-sass:
+
+NodeJS  | Supported node-sass version | Node Module
+--------|-----------------------------|------------
+Node 14 | 4.14+                       | 83
+Node 13 | 4.13+, <5.0                 | 79
+Node 12 | 4.12+                       | 72
+Node 11 | 4.10+, <5.0                 | 67
+Node 10 | 4.9+                        | 64
+Node 8  | 4.5.3+, <5.0                | 57
+Node <8 | <5.0                        | <57
 
 <table>
   <tr>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "http://andrew.github.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=10"
   },
   "main": "lib/index.js",
   "nodeSassConfig": {


### PR DESCRIPTION
- Add an attempt at a support policy for Node versions at the top of the readme. I removed the old heading text, so some old links might break
- Replaced the Travis status badges with the new GitHub Actions ones
- Removed old status badges for services we don't really rely on

@xzyfer should the Slack on be removed as well? I don't know if it gets much attention by anyone