### PR TITLE
chore: Add Node 15 support

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: node:${{ matrix.node }}-alpine${{ matrix.alpine }}
-      env:
-        SKIP_SASS_BINARY_DOWNLOAD_FOR_CI: true
     strategy:
       fail-fast: false
       matrix:
@@ -20,6 +18,8 @@ jobs:
           - 10
           - 12
           - 14
+          - 15
+
         include:
           - node: 10
             alpine: "3.9"
@@ -27,6 +27,9 @@ jobs:
             alpine: "3.9"
           - node: 14
             alpine: "3.10"
+          - node: 15
+            alpine: "3.10"
+
     steps:
       - name: Install Alpine build tools
         run: apk add --no-cache python make git gcc g++
@@ -35,6 +38,8 @@ jobs:
 
       - name: Install packages
         run: npm install --unsafe-perm
+        env:
+          SKIP_SASS_BINARY_DOWNLOAD_FOR_CI: true
 
       - name: Run tests
         run: npm test

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,6 +17,8 @@ jobs:
           - 10
           - 12
           - 14
+          - 15
+
         include:
           - node: 10
             gcc: "gcc-4.9"
@@ -30,6 +32,11 @@ jobs:
             gcc: "gcc-6"
             gpp: "g++-6"
             os: ubuntu-18.04
+          - node: 15
+            gcc: "gcc-6"
+            gpp: "g++-6"
+            os: ubuntu-18.04
+
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,6 +17,7 @@ jobs:
           - 10
           - 12
           - 14
+          - 15
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2016
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
@@ -17,6 +17,17 @@ jobs:
           - 10
           - 12
           - 14
+          - 15
+
+        include:
+          - node: 10
+            os: windows-2016
+          - node: 12
+            os: windows-2016
+          - node: 14
+            os: windows-2016
+          - node: 15
+            os: windows-2019
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Below is a quick guide for minimum and maximum support supported version of node
 
 NodeJS  | Supported node-sass version | Node Module
 --------|-----------------------------|------------
+Node 15 | 5.0+                        | 88
 Node 14 | 4.14+                       | 83
 Node 13 | 4.13+, <5.0                 | 79
 Node 12 | 4.12+                       | 72

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,6 +42,9 @@
       - nodejs_version: 14
         GYP_MSVS_VERSION: 2017
         APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      - nodejs_version: 15
+        GYP_MSVS_VERSION: 2019
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
 
   install:
     # https://www.appveyor.com/docs/lang/nodejs-iojs/#installing-any-version-of-nodejs-or-iojs
@@ -118,6 +121,9 @@
       - nodejs_version: 14
         GYP_MSVS_VERSION: 2017
         APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      - nodejs_version: 15
+        GYP_MSVS_VERSION: 2019
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
 
   install:
     # https://www.appveyor.com/docs/lang/nodejs-iojs/#installing-any-version-of-nodejs-or-iojs

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -80,6 +80,7 @@ function getHumanNodeVersion(abi) {
     case 72: return 'Node.js 12.x';
     case 79: return 'Node.js 13.x';
     case 83: return 'Node.js 14.x';
+    case 88: return 'Node.js 15.x';
     default: return false;
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint bin/node-sass lib scripts test",
     "test": "mocha test/{*,**/**}.js",
     "build": "node scripts/build.js --force",
-    "prepublish": "not-in-install && node scripts/prepublish.js || in-install"
+    "prepublishOnly ": "scripts/prepublish.js"
   },
   "files": [
     "bin",
@@ -59,7 +59,6 @@
     "gaze": "^1.0.0",
     "get-stdin": "^4.0.1",
     "glob": "^7.0.3",
-    "in-publish": "^2.0.0",
     "lodash": "^4.17.15",
     "meow": "^3.7.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
This should fail till the actual v15 of Node comes out.
Platform compiler requirements based off of https://github.com/nodejs/build/issues/2423