### PR TITLE
Remove workarounds for old Node.js versions

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -310,10 +310,6 @@ function getBinaryPath() {
     binaryPath = path.join(getBinaryDir(), getBinaryName().replace(/_(?=binding\.node)/, '/'));
   }
 
-  if (process.versions.modules < 46) {
-    return binaryPath;
-  }
-
   try {
     return trueCasePathSync(binaryPath) || binaryPath;
   } catch (e) {
@@ -433,12 +429,6 @@ function getPlatformVariant() {
 
   try {
     contents = fs.readFileSync(process.execPath);
-
-    // Buffer.indexOf was added in v1.5.0 so cast to string for old node
-    // Delay contents.toStrings because it's expensive
-    if (!contents.indexOf) {
-      contents = contents.toString();
-    }
 
     if (contents.indexOf('libc.musl-x86_64.so.1') !== -1) {
       return 'musl';


### PR DESCRIPTION
Cherrypicked from v5 branch