### PR TITLE
chore: Don't double build DependaBot PRs

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -1,6 +1,10 @@
 name: Build bindings for Alpine releases
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - "dependabot/**"
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,8 @@ name: Coverage
 
 on:
   push:
+    branches-ignore:
+      - "dependabot/**"
     paths:
       - ".nycrc.json"
       - "**/*.js"

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -2,6 +2,8 @@ name: Lint JS
 
 on:
   push:
+    branches-ignore:
+      - "dependabot/**"
     paths:
       - "**/*.js"
       - ".eslintrc.json"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,10 @@
 name: Build bindings for Linux releases
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - "dependabot/**"
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,10 @@
 name: Build bindings for macOS releases
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - "dependabot/**"
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,10 @@
 name: Build bindings for Windows releases
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - "dependabot/**"
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION

These are submitted by PR, so branches don't need to build