### PR TITLE
Remove rejectUnauthorized:false from download flags

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -18,6 +18,13 @@ should always follow these steps before opening a new issue.
 
 ## Installation
 
+### Problems Downloading node-sass
+
+If node-sass is unable to download the sass binary, please download the correct build
+for your node version and platform from the [releases page](https://github.com/sass/node-sass/releases)
+and use the [binary configuration parameters](https://github.com/sass/node-sass/blob/master/README.md#binary-configuration-parameters)
+to manually use the downloaded binary. This may occur if your ISP/organisation is interfering with https connections.
+
 ### 404s
 
 If you see a 404 when trying to install node-sass, this indicates that you're trying

--- a/scripts/util/downloadoptions.js
+++ b/scripts/util/downloadoptions.js
@@ -14,7 +14,6 @@ var proxy = require('./proxy'),
  */
 module.exports = function() {
   var options = {
-    rejectUnauthorized: false,
     timeout: 60000,
     headers: {
       'User-Agent': userAgent(),

--- a/test/downloadoptions.js
+++ b/test/downloadoptions.js
@@ -8,7 +8,6 @@ describe('util', function() {
     describe('without a proxy', function() {
       it('should look as we expect', function() {
         var expected = {
-          rejectUnauthorized: false,
           timeout: 60000,
           headers: {
             'User-Agent': ua(),
@@ -33,7 +32,6 @@ describe('util', function() {
 
       it('should look as we expect', function() {
         var expected = {
-          rejectUnauthorized: false,
           proxy: proxy,
           timeout: 60000,
           headers: {
@@ -59,7 +57,6 @@ describe('util', function() {
 
       it('should look as we expect', function() {
         var expected = {
-          rejectUnauthorized: false,
           timeout: 60000,
           headers: {
             'User-Agent': ua(),


### PR DESCRIPTION
This should resolve https://github.com/sass/node-sass/issues/3067 `rejectUnauthorized: false` was added in https://github.com/sass/node-sass/pull/567 

It would seem more important to resolve the CVE-2020-24025 than to support misconfigured enterprise proxies. 
