### PR TITLE
fix(docs): corrects common typos in project documentation

### DIFF
--- a/src/libsass/.github/CONTRIBUTING.md
+++ b/src/libsass/.github/CONTRIBUTING.md
@@ -32,7 +32,7 @@ direction for corners that lack test coverage). Foremost we rely on good and con
 
 ## My error is hiding in a big code base
 1. we do not have time to support your code base!
-2. to fix occuring issues we need precise bug reports
+2. to fix occurring issues we need precise bug reports
 3. the more precise you are, the faster we can help you
 4. lazy reports get overlooked even when exposing serious bugs
 5. it's not hard to do, it only takes time

--- a/src/libsass/docs/api-context.md
+++ b/src/libsass/docs/api-context.md
@@ -171,7 +171,7 @@ struct Sass_Compiler* sass_make_file_compiler (struct Sass_File_Context* file_ct
 struct Sass_Compiler* sass_make_data_compiler (struct Sass_Data_Context* data_ctx);
 
 // Execute the different compilation steps individually
-// Usefull if you only want to query the included files
+// Useful if you only want to query the included files
 int sass_compiler_parse (struct Sass_Compiler* compiler);
 int sass_compiler_execute (struct Sass_Compiler* compiler);
 

--- a/src/libsass/docs/api-doc.md
+++ b/src/libsass/docs/api-doc.md
@@ -152,7 +152,7 @@ const char* libsass_language_version(void);
 
 The `input_path` is part of `Sass_Options`, but it also is the main option for
 `Sass_File_Context`. It is also used to generate relative file links in source-
-maps. Therefore it is pretty usefull to pass this information if you have a
+maps. Therefore it is pretty useful to pass this information if you have a
 `Sass_Data_Context` and know the original path.
 
 **output_path**

--- a/src/libsass/docs/api-value-example.md
+++ b/src/libsass/docs/api-value-example.md
@@ -31,7 +31,7 @@ int main( int argc, const char* argv[] )
   sass_delete_value(total);
 
   // print the result - you may want to make
-  // sure result is indeed a string, altough
+  // sure result is indeed a string, although
   // stringify guarantees to return a string
   // if (sass_value_is_string(result)) {}
   // really depends on your level of paranoia

--- a/src/libsass/docs/compatibility-plan.md
+++ b/src/libsass/docs/compatibility-plan.md
@@ -1,6 +1,6 @@
 This document is to serve as a living, changing plan for getting LibSass caught up with Ruby Sass.
 
-_Note: an "s" preceeding a version number is specifying a Ruby Sass version. Without an s, it's a version of LibSass._
+_Note: an "s" preceding a version number is specifying a Ruby Sass version. Without an s, it's a version of LibSass._
 
 # Goal
 **Our goal is to reach full s3.4 compatibility as soon as possible. LibSass version 3.4 will behave just like Ruby Sass 3.4**

--- a/src/libsass/docs/dev-ast-memory.md
+++ b/src/libsass/docs/dev-ast-memory.md
@@ -50,7 +50,7 @@ I often use the terminology of "pickup". This means the moment when
 a raw pointer not under any control is assigned to a reference counted
 object (`XYZ_Obj = XYZ_Ptr`). From that point on memory will be
 automatically released once the object goes out of scope (but only
-if the reference counter reaches zero). Main point beeing, you don't
+if the reference counter reaches zero). Main point being, you don't
 have to worry about memory management yourself.
 
 ### Object detach
@@ -212,7 +212,7 @@ profound advantages:
 
 - Better GCC 4.4 compatibility (which most code still has OOTB)
 - Not thread safe (give us some free performance on some compiler)
-- Beeing able to track memory allocations for debugging purposes
+- Being able to track memory allocations for debugging purposes
 - Adding additional features if needed (as seen in `detach`)
 - Optional: optimized weak pointer implementation possible
 

--- a/src/libsass/docs/source-map-internals.md
+++ b/src/libsass/docs/source-map-internals.md
@@ -28,7 +28,7 @@ if (lex< custom_property_name >()) {
 
 ## How is the `source_position` calculated
 
-This is automatically done with `lex` in `parser.hpp`. Whenever something is lexed, the `source_position` is updated. But be aware that `source_position` points to the begining of the parsed text. If you need a mapping for the position where the parsing ended, you need to add another call to `lex` (to match nothing)!
+This is automatically done with `lex` in `parser.hpp`. Whenever something is lexed, the `source_position` is updated. But be aware that `source_position` points to the beginning of the parsed text. If you need a mapping for the position where the parsing ended, you need to add another call to `lex` (to match nothing)!
 
 ```
 lex< exactly < empty_str > >();

--- a/src/libsass/docs/unicode.md
+++ b/src/libsass/docs/unicode.md
@@ -36,7 +36,7 @@ LibSass currently reads all kind of BOMs and will error out if it finds somethin
 ### Low priority feature
 
 I guess the current implementation should handle more than 99% of all real world use cases.
-A) Unicode characters are still seldomly seen (as they can be written escaped)
+A) Unicode characters are still seldom seen (as they can be written escaped)
 ~~B) It will still work if it's UTF-8 or in any of the most common known western ISO codepages.
 Although I'm not sure how this applies to asian and other "exotic" codepages!~~
 


### PR DESCRIPTION
Scope of changes is restricted to markdown docs only. Changes are made in agreement with Standard American English.