### PR TITLE
chore: Use default Apline version from docker-node

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -22,13 +22,13 @@ jobs:
 
         include:
           - node: 12
-            alpine: "3.9"
-          - node: 14
-            alpine: "3.10"
-          - node: 15
-            alpine: "3.10"
-          - node: 16
             alpine: "3.11"
+          - node: 14
+            alpine: "3.11"
+          - node: 15
+            alpine: "3.11"
+          - node: 16
+            alpine: "3.13"
 
     steps:
       - name: Install Alpine build tools

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: node:${{ matrix.node }}-alpine${{ matrix.alpine }}
+      image: node:${{ matrix.node }}-alpine
     strategy:
       fail-fast: false
       matrix:
@@ -22,16 +22,12 @@ jobs:
 
         include:
           - node: 12
-            alpine: "3.11"
             python: python2
           - node: 14
-            alpine: "3.11"
             python: python3
           - node: 15
-            alpine: "3.11"
             python: python3
           - node: 16
-            alpine: "3.13"
             python: python3
 
     steps:

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -23,16 +23,20 @@ jobs:
         include:
           - node: 12
             alpine: "3.11"
+            python: python2
           - node: 14
             alpine: "3.11"
+            python: python3
           - node: 15
             alpine: "3.11"
+            python: python3
           - node: 16
             alpine: "3.13"
+            python: python3
 
     steps:
       - name: Install Alpine build tools
-        run: apk add --no-cache python make git gcc g++
+        run: apk add --no-cache ${{ matrix.python }} make git gcc g++
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Matching the current defaults from https://github.com/nodejs/docker-node/blob/main/versions.json
A bunch of the current defaults are EOL versions of Alpine, so the tags are out of date