### PR TITLE
Use make-fetch-happen instead of request

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -22,7 +22,7 @@ jobs:
 
         include:
           - node: 12
-            python: python2
+            python: python3
           - node: 14
             python: python3
           - node: 15

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -22,7 +22,7 @@ jobs:
 
         include:
           - node: 12
-            python: python3
+            python: python2
           - node: 14
             python: python3
           - node: 15

--- a/package.json
+++ b/package.json
@@ -60,11 +60,10 @@
     "get-stdin": "^4.0.1",
     "glob": "^7.0.3",
     "lodash": "^4.17.15",
+    "make-fetch-happen": "^9.1.0",
     "meow": "^9.0.0",
     "nan": "^2.13.2",
-    "node-gyp": "^7.1.0",
-    "npmlog": "^5.0.0",
-    "request": "^2.88.0",
+    "node-gyp": "^8.2.0",
     "sass-graph": "2.2.5",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "make-fetch-happen": "^9.1.0",
     "meow": "^9.0.0",
     "nan": "^2.13.2",
-    "node-gyp": "^8.2.0",
+    "node-gyp": "^7.1.0",
     "sass-graph": "2.2.5",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^1.0.2"

--- a/scripts/util/downloadoptions.js
+++ b/scripts/util/downloadoptions.js
@@ -2,24 +2,17 @@ var proxy = require('./proxy'),
   userAgent = require('./useragent');
 
 /**
- * The options passed to request when downloading the bibary
+ * The options passed to make-fetch-happen when downloading the binary
  *
- * There some nuance to how request handles options. Specifically
- * we've been caught by their usage of `hasOwnProperty` rather than
- * falsey checks. By moving the options generation into a util helper
- * we can test for regressions.
- *
- * @return {Object} an options object for request
+ * @return {Object} an options object for make-fetch-happen
  * @api private
  */
 module.exports = function() {
   var options = {
-    rejectUnauthorized: false,
     timeout: 60000,
     headers: {
       'User-Agent': userAgent(),
     },
-    encoding: null,
   };
 
   var proxyConfig = proxy();

--- a/scripts/util/downloadoptions.js
+++ b/scripts/util/downloadoptions.js
@@ -9,6 +9,7 @@ var proxy = require('./proxy'),
  */
 module.exports = function() {
   var options = {
+    strictSSL: false,
     timeout: 60000,
     headers: {
       'User-Agent': userAgent(),

--- a/test/downloadoptions.js
+++ b/test/downloadoptions.js
@@ -8,12 +8,10 @@ describe('util', function() {
     describe('without a proxy', function() {
       it('should look as we expect', function() {
         var expected = {
-          rejectUnauthorized: false,
           timeout: 60000,
           headers: {
             'User-Agent': ua(),
           },
-          encoding: null,
         };
 
         assert.deepStrictEqual(opts(), expected);
@@ -33,13 +31,11 @@ describe('util', function() {
 
       it('should look as we expect', function() {
         var expected = {
-          rejectUnauthorized: false,
           proxy: proxy,
           timeout: 60000,
           headers: {
             'User-Agent': ua(),
           },
-          encoding: null,
         };
 
         assert.deepStrictEqual(opts(), expected);
@@ -59,12 +55,10 @@ describe('util', function() {
 
       it('should look as we expect', function() {
         var expected = {
-          rejectUnauthorized: false,
           timeout: 60000,
           headers: {
             'User-Agent': ua(),
           },
-          encoding: null,
         };
 
         assert.deepStrictEqual(opts(), expected);

--- a/test/downloadoptions.js
+++ b/test/downloadoptions.js
@@ -68,6 +68,24 @@ describe('util', function() {
       });
     });
 
+    describe('with SASS_REJECT_UNAUTHORIZED set to false', function() {
+      beforeEach(function() {
+        process.env.SASS_REJECT_UNAUTHORIZED = '0';
+      });
+
+      it('should look as we expect', function() {
+        var expected = {
+          strictSSL: false,
+          timeout: 60000,
+          headers: {
+            'User-Agent': ua(),
+          },
+        };
+
+        assert.deepStrictEqual(opts(), expected);
+      });
+    });
+
     describe('with SASS_REJECT_UNAUTHORIZED set to true', function() {
       beforeEach(function() {
         process.env.SASS_REJECT_UNAUTHORIZED = '1';
@@ -75,12 +93,11 @@ describe('util', function() {
 
       it('should look as we expect', function() {
         var expected = {
-          rejectUnauthorized: true,
+          strictSSL: true,
           timeout: 60000,
           headers: {
             'User-Agent': ua(),
           },
-          encoding: null,
         };
 
         assert.deepStrictEqual(opts(), expected);
@@ -94,12 +111,11 @@ describe('util', function() {
 
       it('should look as we expect', function() {
         var expected = {
-          rejectUnauthorized: true,
+          strictSSL: true,
           timeout: 60000,
           headers: {
             'User-Agent': ua(),
           },
-          encoding: null,
         };
 
         assert.deepStrictEqual(opts(), expected);

--- a/test/downloadoptions.js
+++ b/test/downloadoptions.js
@@ -8,6 +8,7 @@ describe('util', function() {
     describe('without a proxy', function() {
       it('should look as we expect', function() {
         var expected = {
+          strictSSL: false,
           timeout: 60000,
           headers: {
             'User-Agent': ua(),
@@ -31,6 +32,7 @@ describe('util', function() {
 
       it('should look as we expect', function() {
         var expected = {
+          strictSSL: false,
           proxy: proxy,
           timeout: 60000,
           headers: {
@@ -55,6 +57,7 @@ describe('util', function() {
 
       it('should look as we expect', function() {
         var expected = {
+          strictSSL: false,
           timeout: 60000,
           headers: {
             'User-Agent': ua(),


### PR DESCRIPTION
cf: https://github.com/sass/node-sass/issues/2851

Follows the implementation that was done here: https://github.com/sass/node-sass/pull/2961 ; also remove `npmlog` that seems unused from here on.

Because the latest node-gyp does not support python2 (https://github.com/nodejs/node-gyp/blob/master/CHANGELOG.md#810-2021-05-28), use python3 for all nodes builds/tests. (Not sure if `src/libsass/script/ci-report-coverage:8` should be affected?)

