### PR TITLE
ci: use Python 3 for Node 12

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -22,7 +22,7 @@ jobs:
 
         include:
           - node: 12
-            python: python2
+            python: python3
           - node: 14
             python: python3
           - node: 16


### PR DESCRIPTION
New node-gyp no longer supports Python 2