### PR TITLE
chore: bump GitHub Actions to Windows 2019

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,9 +25,9 @@ jobs:
 
         include:
           - node: 12
-            os: windows-2016
+            os: windows-2019
           - node: 14
-            os: windows-2016
+            os: windows-2019
           - node: 16
             os: windows-2019
           - node: 17


### PR DESCRIPTION
Fixes #3212