### PR TITLE
Bump sass-graph from 4.0.0 to 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "meow": "^9.0.0",
     "nan": "^2.13.2",
     "node-gyp": "^9.0.0",
-    "sass-graph": "4.0.0",
+    "sass-graph": "4.0.1",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^2.2.1"
   },


### PR DESCRIPTION
I received this warning in one of my projects today.  It appears `sass-graph` bumped the conflicting dependency and released 4.0.1 as a new minor version to rectify it.

![image](https://user-images.githubusercontent.com/3603112/188186066-9a86eeea-3bde-43de-a095-f3ef557b0345.png)
