### PR TITLE
Bump node-gyp and nan for node 19 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     "lodash": "^4.17.15",
     "make-fetch-happen": "^10.0.4",
     "meow": "^9.0.0",
-    "nan": "^2.13.2",
-    "node-gyp": "^9.0.0",
+    "nan": "^2.17.0",
+    "node-gyp": "^8.4.1",
     "sass-graph": "^4.0.1",
     "stdout-stream": "^1.4.0",
     "true-case-path": "^2.2.1"


### PR DESCRIPTION
Fixed failing binary compilations on Node 19.